### PR TITLE
Update publish script to perform a restore.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Microsoft IIS Administration API
 ### Publish and Install: ###
 * Run PowerShell as an Administrator
 * Run the Publish.ps1 script located in the scripts directory
-* \<OutputDirectory>\setup\setup.ps1 Install -verbose
+* \<OutputDirectory>\setup\setup.ps1 Install -Verbose
 
 ### Using the new API ###
 1. Navigate to https://manage.iis.net?api_url=localhost

--- a/scripts/publish/publish.ps1
+++ b/scripts/publish/publish.ps1
@@ -13,6 +13,13 @@ Param(
     [switch]
     $ConfigDebug,
     
+    # Flag to skip restoring the projects
+    # Using this flag reduces publish time but can only be used after an initial publish
+    # Any change in dependencies will require a restore
+    [parameter()]
+    [switch]
+    $SkipRestore,
+    
     # Flag to automatically remove the content located at the output path
     [parameter()]
     [switch]
@@ -163,6 +170,10 @@ if(!$configPathExists) {
 
 try {
     dotnet -v | Out-Null
+
+	if ($LASTEXITCODE -ne 0) {
+		throw ".NET SDK not installed"
+	}
 }
 catch {
     Write-Warning $_.Exception.Message
@@ -178,6 +189,14 @@ New-Item -type Directory $applicationPath -ErrorAction Stop | out-null
 $configuration = "Release"
 if($ConfigDebug) {
 	$configuration = "Debug"
+}
+
+if (-not($SkipRestore)) {
+    dotnet restore $(Get-SolutionDirectory)
+
+	if ($LASTEXITCODE -ne 0) {
+		throw "Restore failed"
+	}
 }
 
 try {


### PR DESCRIPTION
With this change publishing from a clean copy of the repository works correctly. Publishing still requires the .NET Core SDK to run successfully.

This addresses #15. 