### PR TITLE
Update the httpClient instructions to include HttpClientHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,11 @@ There is a blog post to get up and running on Nano Server located at https://blo
 
 ### Intialize Api Client ###
 ```
-var apiClient = new HttpClient();
+var httpClientHandler = new HttpClientHandler()
+    {
+        Credentials = new NetworkCredential(userName, password, domain)
+    };
+var apiClient = new HttpClient(httpClientHandler);
 // Set access token for every request
 apiClient.DefaultRequestHeaders.Add("Access-Token", "Bearer {token}");
 ```


### PR DESCRIPTION
By default, the site is set to use Windows authentication.  The user can either turn that off, or alter the `HttpClient` example in the Readme to include the proper network credentials.

Closes #21 