### PR TITLE
Fixed bug in bindings caused by non HTTP binding types.

### DIFF
--- a/test/Microsoft.IIS.Administration.Tests/Applications.cs
+++ b/test/Microsoft.IIS.Administration.Tests/Applications.cs
@@ -15,7 +15,7 @@ namespace Microsoft.IIS.Administration.Tests
     public class Applications
     {
         private const string TEST_APPLICATION_SITE_NAME = "test_application_site";
-        private static readonly string TEST_APPLICATION_SITE = $"{{ \"bindings\": [ {{ \"ip_address\": \"*\", \"port\": \"50307\", \"is_https\": \"false\" }} ], \"physical_path\": \"c:\\\\sites\\\\test_site\" , \"name\": \"{TEST_APPLICATION_SITE_NAME}\" }}";
+        private static readonly string TEST_APPLICATION_SITE = $"{{ \"bindings\": [ {{ \"ip_address\": \"*\", \"port\": \"50307\", \"protocol\": \"http\" }} ], \"physical_path\": \"c:\\\\sites\\\\test_site\" , \"name\": \"{TEST_APPLICATION_SITE_NAME}\" }}";
         private static string TEST_APPLICATION = "{ \"path\" : \"/test_application\", \"physical_path\" : \"c:\\\\sites\\\\test_site\\\\test_application\", \"website\":{ \"id\" : \"{site_id}\" } }";
         ITestOutputHelper _output;
 

--- a/test/Microsoft.IIS.Administration.Tests/HttpClientExtensions.cs
+++ b/test/Microsoft.IIS.Administration.Tests/HttpClientExtensions.cs
@@ -50,16 +50,26 @@ namespace Microsoft.IIS.Administration.Tests
 
         public static bool Patch(this HttpClient client, string uri, string body, out string result)
         {
+            var response = PatchRaw(client, uri, body);
+            result = response.Content.ReadAsStringAsync().Result;
+            return Globals.Success(response);
+        }
+
+        public static HttpResponseMessage PatchRaw(this HttpClient client, string uri, string body)
+        {
             HttpContent content = new StringContent(body, Encoding.UTF8, "application/json");
-            HttpRequestMessage requestMessage = new HttpRequestMessage(new HttpMethod("PATCH"), uri) {
+            HttpRequestMessage requestMessage = new HttpRequestMessage(new HttpMethod("PATCH"), uri)
+            {
                 Content = content
             };
 
-            HttpResponseMessage response = client.SendAsync(requestMessage).Result;
+            return client.SendAsync(requestMessage).Result;
+        }
 
-            result = response.Content.ReadAsStringAsync().Result;
-
-            return Globals.Success(response);
+        public static HttpResponseMessage PatchRaw(this HttpClient client, string uri, object body)
+        {
+            string sBody = JsonConvert.SerializeObject(body);
+            return PatchRaw(client, uri, sBody);
         }
 
         public static bool Patch(this HttpClient client, string uri, object body, out string result)

--- a/test/Microsoft.IIS.Administration.Tests/Utils.cs
+++ b/test/Microsoft.IIS.Administration.Tests/Utils.cs
@@ -205,6 +205,7 @@ namespace Microsoft.IIS.Administration.Tests
 
             try {
                 tcp.ConnectAsync("localhost", port).RunSynchronously();
+
                 return false;
             }
             catch {

--- a/test/Microsoft.IIS.Administration.Tests/VirtualDirectories.cs
+++ b/test/Microsoft.IIS.Administration.Tests/VirtualDirectories.cs
@@ -15,7 +15,7 @@ namespace Microsoft.IIS.Administration.Tests
     public class VirtualDirectories
     {
         private const string TEST_SITE_NAME = "test_vdir_site";
-        public static readonly string TEST_SITE = $"{{ \"bindings\": [ {{ \"ip_address\": \"*\", \"port\": \"50308\", \"is_https\": \"false\" }} ], \"physical_path\": \"c:\\\\sites\\\\test_site\" , \"name\": \"{TEST_SITE_NAME}\" }}";
+        public static readonly string TEST_SITE = $"{{ \"bindings\": [ {{ \"ip_address\": \"*\", \"port\": \"50308\", \"protocol\": \"http\" }} ], \"physical_path\": \"c:\\\\sites\\\\test_site\" , \"name\": \"{TEST_SITE_NAME}\" }}";
         public static string TEST_APPLICATION = "{ \"path\" : \"/test_vdir_application\", \"physical_path\" : \"c:\\\\sites\\\\test_site\\\\test_application\", \"website\" : { \"id\" : \"{site_id}\" } }";
         public static string TEST_VDIR = "{ \"path\" : \"/test_vdir\", \"physical_path\" : \"c:\\\\sites\\\\test_site\\\\test_vdir\", \"webapp\" : { \"id\" : \"{app_id}\" } }";
         ITestOutputHelper _output;


### PR DESCRIPTION
Added support for non HTTP binding types.

The 'is_http" property of bindings has been removed in favor of the 'protocol' property.

'binding_information' was added to bindings. This allows full customization of custom protocols. Can also be used to manipulate bindings using the http or https protocols.

bindings with 'protocol' values of _http_ or _https_ are special, they return with 'ip_address', 'port', and 'hostname' properties. These bindings can be manipulated by these extra properties or 'binding_information'.

This fixes #25 


```
"bindings": [
        {
            "protocol": "net.tcp",
            "binding_information": "808:*"
        },
        {
            "protocol": "http",
            "binding_information": "*:65535:",
            "ip_address": "*",
            "port": "65535",
            "hostname": ""
        },
        {
            "protocol": "https",
            "binding_information": "*:443:",
            "ip_address": "*",
            "port": "443",
            "hostname": "",
            "certificate": {
                "name": "Microsoft IIS Administration Server Certificate",
                "id": "Y2bEphJ-56gRWLi3Fijmxl62tlBwmlSE0hsbaqwgQ207kur2gzamVSHykgaRElx4",
                "issued_by": "CN=localhost",
                "thumbprint": "E48565392F7C3C5C4DFFE673EE9E1A2E159C00F7",
                "valid_to": "2018-10-18T09:53:06Z",
                "_links": {
                    "self": {
                        "href": "/api/certificates/Y2bEphJ-56gRWLi3Fijmxl62tlBwmlSE0hsbaqwgQ207kur2gzamVSHykgaRElx4"
                    }
                }
            }
        }
    ]
```