### PR TITLE
Change the default access token lifetime to 1 year. (Up from 3 months).

### DIFF
--- a/src/Microsoft.IIS.Administration.Certificates/Controllers/CertificatesController.cs
+++ b/src/Microsoft.IIS.Administration.Certificates/Controllers/CertificatesController.cs
@@ -11,10 +11,12 @@ namespace Microsoft.IIS.Administration.Certificates
     using System.Linq;
     using Core.Http;
     using Core.Utils;
+    using Core;
 
     public class CertificatesController : ApiBaseController
     {
         [HttpGet]
+        [ResourceInfo(Name = Defines.CertificatesName)]
         public object Get()
         {            
             List<object> refs = new List<object>();
@@ -54,6 +56,7 @@ namespace Microsoft.IIS.Administration.Certificates
         }
 
         [HttpGet]
+        [ResourceInfo(Name = Defines.CertificateName)]
         public object Get(string id)
         {
             CertificateId certId = new CertificateId(id);

--- a/src/Microsoft.IIS.Administration.WebServer.Applications/project.json
+++ b/src/Microsoft.IIS.Administration.WebServer.Applications/project.json
@@ -12,6 +12,6 @@
     }
   },
   "dependencies": {
-    "Microsoft.IIS.Administration.WebServer.Sites": "1.0.0"
+    "Microsoft.IIS.Administration.WebServer.Sites": "1.0.1"
   }
 }

--- a/src/Microsoft.IIS.Administration.WebServer.Logging/project.json
+++ b/src/Microsoft.IIS.Administration.WebServer.Logging/project.json
@@ -12,6 +12,6 @@
     }
   },
   "dependencies": {
-    "Microsoft.IIS.Administration.WebServer.Sites": "1.0.0"
+    "Microsoft.IIS.Administration.WebServer.Sites": "1.0.1"
   }
 }

--- a/src/Microsoft.IIS.Administration.WebServer.RequestMonitor/project.json
+++ b/src/Microsoft.IIS.Administration.WebServer.RequestMonitor/project.json
@@ -13,6 +13,6 @@
   },
   "dependencies": {
     "Microsoft.IIS.Administration.WebServer.WorkerProcesses": "1.0.0",
-    "Microsoft.IIS.Administration.WebServer.Sites": "1.0.0"
+    "Microsoft.IIS.Administration.WebServer.Sites": "1.0.1"
   }
 }

--- a/src/Microsoft.IIS.Administration.WebServer.Sites/project.json
+++ b/src/Microsoft.IIS.Administration.WebServer.Sites/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Microsoft.IIS.Administration.WebServer.Sites Class Library",
   "authors": [ "Microsoft" ],
   "frameworks": {

--- a/src/Microsoft.IIS.Administration/Hal/HalService.cs
+++ b/src/Microsoft.IIS.Administration/Hal/HalService.cs
@@ -83,8 +83,8 @@ namespace Microsoft.IIS.Administration
 
         private void SetHalContentType()
         {
-            if (!HttpHelper.Current.Response.HasStarted) {
-                HttpHelper.Current.Response.Headers[HeaderNames.ContentType] = HeaderValues.Hal;
+            if (!HttpHelper.Current.Response.HasStarted && HttpHelper.Current.Response.ContentType == null) {
+                HttpHelper.Current.Response.ContentType = HeaderValues.Hal;
             }
         }
 

--- a/src/Microsoft.IIS.Administration/Views/AccessKeys/Index.cshtml
+++ b/src/Microsoft.IIS.Administration/Views/AccessKeys/Index.cshtml
@@ -64,9 +64,9 @@
                 <label>Expires in</label>
                 <ul class="radio-row">
                     <li date-days="1">1 DAY</li>
-                    <li date-months="1" class="selected">1 MONTH</li>
+                    <li date-months="1">1 MONTH</li>
                     <li date-months="3">3 MONTHS</li>
-                    <li date-years="1">1 YEAR</li>
+                    <li date-years="1" class="selected">1 YEAR</li>
                     <li class="never" title="Allow access until the key is deleted from the list">NEVER</li>
                 </ul>
                 <input type="hidden" name="expiration" value="">

--- a/src/Microsoft.IIS.Administration/project.json
+++ b/src/Microsoft.IIS.Administration/project.json
@@ -1,4 +1,5 @@
 {
+  "version": "1.0.1",
   "commands": {
     "web": "Microsoft.AspNet.Server.Kestrel"
   },
@@ -65,7 +66,6 @@
       "plugins"
     ]
   },
-  "version": "1.0.0",
   "webroot": "wwwroot",
 
   "scripts": {

--- a/src/Packager/project.json
+++ b/src/Packager/project.json
@@ -26,7 +26,7 @@
     "Microsoft.IIS.Administration.WebServer.RequestFiltering": "1.0.0",
     "Microsoft.IIS.Administration.WebServer.RequestMonitor": "1.0.0",
     "Microsoft.IIS.Administration.WebServer.Scm": "1.0.0",
-    "Microsoft.IIS.Administration.WebServer.Sites": "1.0.0",
+    "Microsoft.IIS.Administration.WebServer.Sites": "1.0.1",
     "Microsoft.IIS.Administration.WebServer.SslSettings": "1.0.0",
     "Microsoft.IIS.Administration.WebServer.StaticContent": "1.0.0",
     "Microsoft.IIS.Administration.WebServer.Transactions": "1.0.0",


### PR DESCRIPTION
Fixed issue where resource content types were being overwritten.