### PR TITLE
Changed default log file location.

### DIFF
--- a/src/Microsoft.IIS.Administration/Logging/AuditingConfiguration.cs
+++ b/src/Microsoft.IIS.Administration/Logging/AuditingConfiguration.cs
@@ -4,9 +4,11 @@
 
 namespace Microsoft.IIS.Administration.Logging
 {
+    using AspNetCore.Hosting;
     using Extensions.Configuration;
     using Extensions.Logging;
     using System;
+    using System.IO;
 
     class AuditingConfiguration
     {
@@ -21,6 +23,11 @@ namespace Microsoft.IIS.Administration.Logging
             AuditingRoot = Environment.ExpandEnvironmentVariables(configuration.GetValue("auditing:path", string.Empty));
             MinLevel = LogLevel.Information;
             FileName = configuration.GetValue("auditing:file_name", "audit-{Date}.txt");
+        }
+
+        public string GetDefaultAuditRoot(IHostingEnvironment env)
+        {
+            return Path.GetFullPath(Path.Combine(env.ContentRootPath, "../../logs"));
         }
     }
 }

--- a/src/Microsoft.IIS.Administration/Logging/LoggingConfiguration.cs
+++ b/src/Microsoft.IIS.Administration/Logging/LoggingConfiguration.cs
@@ -4,10 +4,12 @@
 
 namespace Microsoft.IIS.Administration.Logging
 {
+    using AspNetCore.Hosting;
     using Extensions.Configuration;
     using Extensions.Logging;
     using Serilog.Events;
     using System;
+    using System.IO;
 
     class LoggingConfiguration
     {
@@ -42,6 +44,11 @@ namespace Microsoft.IIS.Administration.Logging
                 default:
                     return (LogEventLevel.Fatal + 1);
             }
+        }
+
+        public string GetDefaultLogRoot(IHostingEnvironment env)
+        {
+            return Path.GetFullPath(Path.Combine(env.ContentRootPath, "../../logs"));
         }
     }
 }

--- a/src/Microsoft.IIS.Administration/Logging/LoggingExtensions.cs
+++ b/src/Microsoft.IIS.Administration/Logging/LoggingExtensions.cs
@@ -17,11 +17,10 @@ namespace Microsoft.IIS.Administration.Logging
     {
         public static IServiceCollection AddApiLogging(this IServiceCollection services, IConfiguration configuration, IHostingEnvironment env)
         {
-            var defaultLogsRoot = Path.GetFullPath(Path.Combine(env.ContentRootPath, "logs"));
-
             var loggingConfiguration = new LoggingConfiguration(configuration);
             var logsRoot = loggingConfiguration.LogsRoot;
             var minLevel = loggingConfiguration.MinLevel;
+            var defaultLogsRoot = loggingConfiguration.GetDefaultLogRoot(env);
 
             // If invalid directory was specified in the configuration. Reset to default
             if (!Directory.Exists(logsRoot)) {
@@ -50,11 +49,10 @@ namespace Microsoft.IIS.Administration.Logging
 
         public static IServiceCollection AddApiAuditing(this IServiceCollection services, IConfiguration configuration, IHostingEnvironment env)
         {
-            var defaultAuditRoot = Path.GetFullPath(Path.Combine(env.ContentRootPath, "logs"));
-
             var auditingConfiguration = new AuditingConfiguration(configuration);
             var auditRoot = auditingConfiguration.AuditingRoot;
             var minLevel = auditingConfiguration.MinLevel;
+            var defaultAuditRoot = auditingConfiguration.GetDefaultAuditRoot(env);
 
             // If invalid directory was specified in the configuration. Reset to default
             if (!Directory.Exists(auditRoot)) {


### PR DESCRIPTION
The default log file location was previously located in the application's content root. This resulted in log files not being migrated when upgrading to a newer version of the application. This change moves the default log file location up two levels so that they are untouched when upgrading to newer versions.

The new structure will look as such:
```
C:\Program Files\IIS Administration
  ├ 1.0.38
  └ logs
```