### PR TITLE
Jimmyca15/requesttracing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -219,3 +219,4 @@ _Pvt_Extensions
 src/*/wwwroot/lib
 PublishProfiles
 scripts/publish/version.txt
+src/Microsoft.IIS.Administration/wwwroot/static/Microsoft.IIS.Administration.WebServer.HttpRequestTracing/freb.xsl

--- a/src/Microsoft.IIS.Administration.Core/Exceptions/ApiException.cs
+++ b/src/Microsoft.IIS.Administration.Core/Exceptions/ApiException.cs
@@ -7,12 +7,17 @@ namespace Microsoft.IIS.Administration.Core {
 
 
     public class ApiException : Exception, IError {
+        public string Name { get; private set; }
 
-        public ApiException(string message, Exception innerException) : base(message, innerException) {
+        public ApiException(string message, Exception innerException) : base(message ?? string.Empty, innerException) {
+        }
+
+        public ApiException(string message, string name, Exception innerException) : base(message ?? string.Empty, innerException) {
+            this.Name = name;
         }
 
         public virtual dynamic GetApiError() {
-            return Http.ErrorHelper.Error(Message);
+            return Http.ErrorHelper.Error(Message, Name);
         }
     }
 }

--- a/src/Microsoft.IIS.Administration.Core/Exceptions/ForbiddenArgumentException.cs
+++ b/src/Microsoft.IIS.Administration.Core/Exceptions/ForbiddenArgumentException.cs
@@ -6,16 +6,14 @@ namespace Microsoft.IIS.Administration.Core
 {
     using System;
 
-    public class ForbiddenArgumentException : ApiArgumentException
-    {
+    public class ForbiddenArgumentException : ApiArgumentException {
         public ForbiddenArgumentException(string paramName, Exception innerException = null) : base(paramName, string.Empty, innerException) {
         }
 
         public ForbiddenArgumentException(string paramName, string message, Exception innerException = null) : base(paramName, message == null ? string.Empty : message, innerException) {
         }
 
-        public override dynamic GetApiError()
-        {
+        public override dynamic GetApiError() {
             return Http.ErrorHelper.ForbiddenArgumentError(ParamName, Message);
         }
     }

--- a/src/Microsoft.IIS.Administration.Core/Http/ErrorHelper.cs
+++ b/src/Microsoft.IIS.Administration.Core/Http/ErrorHelper.cs
@@ -9,14 +9,14 @@ namespace Microsoft.IIS.Administration.Core.Http {
 
     public static class ErrorHelper {
 
-        public static dynamic Error(string message) {
+        public static dynamic Error(string message, string name) {
             return new {
                 title = "Server error",
-                detail = message ?? "",
+                detail = message ?? string.Empty,
+                name = name ?? string.Empty,
                 status = (int)HttpStatusCode.InternalServerError
             };
         }
-
 
         public static dynamic ArgumentError(string paramName, string message = null) {
 

--- a/src/Microsoft.IIS.Administration.Files.Core/AccessControl.cs
+++ b/src/Microsoft.IIS.Administration.Files.Core/AccessControl.cs
@@ -4,39 +4,25 @@
 
 namespace Microsoft.IIS.Administration.Files
 {
-    using Extensions.Configuration;
     using System;
     using System.Collections.Generic;
 
     public class AccessControl : IAccessControl
     {
         private IFileOptions _options;
-        private IConfiguration _configuration;
 
-        public AccessControl(IConfiguration configuration)
+        public AccessControl(IFileOptions options)
         {
-            if (configuration == null) {
-                throw new ArgumentNullException(nameof(configuration));
+            if (options == null) {
+                throw new ArgumentNullException(nameof(options));
             }
 
-            _configuration = configuration;
-        }
-
-        private IFileOptions Options
-        {
-            get {
-                if (_options == null) {
-                    IFileOptions options = FileOptions.FromConfiguration(_configuration);
-                    _options = options;
-                }
-
-                return _options;
-            }
+            _options = options;
         }
 
         public IEnumerable<string> GetClaims(string path)
         {
-            var claims = new List<string>();
+            IList<string> claims = new List<string>();
 
             //
             // Path must be absolute with no environment variables
@@ -46,7 +32,7 @@ namespace Microsoft.IIS.Administration.Files
 
             //
             // Best match
-            foreach (var location in Options.Locations) {
+            foreach (var location in _options.Locations) {
 
                 if (HasPrefix(path, location.Path)) {
 

--- a/src/Microsoft.IIS.Administration.Files.Core/Downloads/IDownload.cs
+++ b/src/Microsoft.IIS.Administration.Files.Core/Downloads/IDownload.cs
@@ -4,10 +4,12 @@
 
 namespace Microsoft.IIS.Administration.Files
 {
-    using System.Collections.Generic;
-
-    public interface IFileOptions
+    public interface IDownload
     {
-        IList<ILocation> Locations { get; set; }
+        string Id { get; }
+
+        string PhysicalPath { get; set; }
+
+        string Href { get; }
     }
 }

--- a/src/Microsoft.IIS.Administration.Files.Core/Downloads/IDownloadService.cs
+++ b/src/Microsoft.IIS.Administration.Files.Core/Downloads/IDownloadService.cs
@@ -4,10 +4,12 @@
 
 namespace Microsoft.IIS.Administration.Files
 {
-    using System.Collections.Generic;
-
-    public interface IFileOptions
+    public interface IDownloadService
     {
-        IList<ILocation> Locations { get; set; }
+        IDownload Create(string physicalPath, int? timeout = null);
+
+        void Remove(string id);
+
+        IDownload Get(string id);
     }
 }

--- a/src/Microsoft.IIS.Administration.Files.Core/FileProvider.cs
+++ b/src/Microsoft.IIS.Administration.Files.Core/FileProvider.cs
@@ -7,7 +7,6 @@ namespace Microsoft.IIS.Administration.Files
     using Core;
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.IO;
     using System.Linq;
     using System.Threading.Tasks;
@@ -39,7 +38,6 @@ namespace Microsoft.IIS.Administration.Files
                 var info = new FileInfo(path);
 
                 if (!IsAccessAllowed(path, FileAccess.Read) && (info.Parent == null || !IsAccessAllowed(info.Parent.Path, FileAccess.Read))) {
-
                     throw new ForbiddenArgumentException(p);
                 }
 

--- a/src/Microsoft.IIS.Administration.Files.Core/IFileProvider.cs
+++ b/src/Microsoft.IIS.Administration.Files.Core/IFileProvider.cs
@@ -40,5 +40,7 @@ namespace Microsoft.IIS.Administration.Files
         bool IsAccessAllowed(string path, FileAccess requestedAccess);
 
         void SetFileTime(string path, DateTime? lastAccessed, DateTime? lastModified, DateTime? created);
+
+        IFileOptions Options { get; }
     }
 }

--- a/src/Microsoft.IIS.Administration.Files.Core/IFileRedirectService.cs
+++ b/src/Microsoft.IIS.Administration.Files.Core/IFileRedirectService.cs
@@ -4,10 +4,12 @@
 
 namespace Microsoft.IIS.Administration.Files
 {
-    using System.Collections.Generic;
+    using System;
 
-    public interface IFileOptions
+    public interface IFileRedirectService
     {
-        IList<ILocation> Locations { get; set; }
+        void AddRedirect(string fileName, Func<string> redirectBuilder, bool permanent);
+
+        IRedirect GetRedirect(string fileName);
     }
 }

--- a/src/Microsoft.IIS.Administration.Files.Core/IRedirect.cs
+++ b/src/Microsoft.IIS.Administration.Files.Core/IRedirect.cs
@@ -4,10 +4,12 @@
 
 namespace Microsoft.IIS.Administration.Files
 {
-    using System.Collections.Generic;
+    using System;
 
-    public interface IFileOptions
+    public interface IRedirect
     {
-        IList<ILocation> Locations { get; set; }
+        string Name { get; set; }
+        Func<string> To { get; set; }
+        bool Permanent { get; set; }
     }
 }

--- a/src/Microsoft.IIS.Administration.Files.Core/Settings/FileOptions.cs
+++ b/src/Microsoft.IIS.Administration.Files.Core/Settings/FileOptions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.IIS.Administration.Files
     {
         private FileOptions() { }
 
-        public List<Location> Locations { get; set; }
+        public IList<ILocation> Locations { get; set; }
 
         public static IFileOptions FromConfiguration(IConfiguration configuration)
         {
@@ -22,7 +22,16 @@ namespace Microsoft.IIS.Administration.Files
 
             if (configuration.GetSection("files").GetChildren().Count() > 0) {
                 options = EmptyOptions();
-                ConfigurationBinder.Bind(configuration.GetSection("files"), options);
+
+                foreach (var child in configuration.GetSection("files:locations").GetChildren()) {
+                    var location = Location.FromSection(child);
+                    if (location != null) {
+                        options.Locations.Add(location);
+                    }
+                }
+            }
+
+            if (options != null) {
                 options.InitializeRoots();
             }
 
@@ -49,7 +58,7 @@ namespace Microsoft.IIS.Administration.Files
         {
             return new FileOptions()
             {
-                Locations = new List<Location>()
+                Locations = new List<ILocation>()
             };
         }
 
@@ -67,10 +76,10 @@ namespace Microsoft.IIS.Administration.Files
                     throw;
                 }
             }
-
+            
             //
             // Sort
-            this.Locations.Sort((item1, item2) => {
+            ((List<ILocation>)Locations).Sort((item1, item2) => {
                 return item2.Path.Length - item1.Path.Length;
             });
         }

--- a/src/Microsoft.IIS.Administration.Files.Core/Settings/IFileOptions.cs
+++ b/src/Microsoft.IIS.Administration.Files.Core/Settings/IFileOptions.cs
@@ -8,6 +8,6 @@ namespace Microsoft.IIS.Administration.Files
 
     public interface IFileOptions
     {
-        IList<ILocation> Locations { get; set; }
+        IList<ILocation> Locations { get; }
     }
 }

--- a/src/Microsoft.IIS.Administration.Files.Core/Settings/ILocation.cs
+++ b/src/Microsoft.IIS.Administration.Files.Core/Settings/ILocation.cs
@@ -4,12 +4,12 @@
 
 namespace Microsoft.IIS.Administration.Files
 {
-    public interface IDownloadService
+    using System.Collections.Generic;
+
+    public interface ILocation
     {
-        Download Create(string physicalPath, int? timeout = null);
-
-        void Remove(string id);
-
-        Download Get(string id);
+        string Alias { get; set; }
+        string Path { get; set; }
+        IList<string> Claims { get; set; }
     }
 }

--- a/src/Microsoft.IIS.Administration.Files.Core/Settings/Location.cs
+++ b/src/Microsoft.IIS.Administration.Files.Core/Settings/Location.cs
@@ -4,12 +4,33 @@
 
 namespace Microsoft.IIS.Administration.Files
 {
+    using Extensions.Configuration;
     using System.Collections.Generic;
 
-    public class Location
+    class Location : ILocation
     {
         public string Alias { get; set; }
         public string Path { get; set; }
-        public List<string> Claims { get; set; } = new List<string>();
+        public IList<string> Claims { get; set; } = new List<string>();
+
+        public static Location FromSection(IConfigurationSection section)
+        {
+            string alias = section.GetValue("alias", string.Empty);
+            string path = section.GetValue<string>("path");
+            IList<string> claims = new List<string>();
+            ConfigurationBinder.Bind(section.GetSection("claims"), claims);
+
+            Location location = null;
+
+            if (!string.IsNullOrEmpty(path)) {
+                location = new Location() {
+                    Alias = alias,
+                    Path = path,
+                    Claims = claims
+                };
+            }
+
+            return location;
+        }
     }
 }

--- a/src/Microsoft.IIS.Administration.Files.Core/Utils/PathUtil.cs
+++ b/src/Microsoft.IIS.Administration.Files.Core/Utils/PathUtil.cs
@@ -136,12 +136,6 @@ namespace Microsoft.IIS.Administration.Files
             return new DirectoryInfo(path).Name;
         }
 
-        public static string GetParentPath(string path)
-        {
-            var parent = new DirectoryInfo(path).Parent;
-            return parent == null ? string.Empty : parent.Path;
-        }
-
         private static string GetTempName(string name)
         {
             var bytes = new byte[4];

--- a/src/Microsoft.IIS.Administration.Files.Core/project.json
+++ b/src/Microsoft.IIS.Administration.Files.Core/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Microsoft.IIS.Administration.Files.Core Class Library",
   "authors": [ "Microsoft" ],
   "frameworks": {

--- a/src/Microsoft.IIS.Administration.Files/Controllers/CopyController.cs
+++ b/src/Microsoft.IIS.Administration.Files/Controllers/CopyController.cs
@@ -18,10 +18,10 @@ namespace Microsoft.IIS.Administration.Files
         private IFileProvider _fileService;
         private static ConcurrentDictionary<string, MoveOperation> _copies = new ConcurrentDictionary<string, MoveOperation>();
 
-        public CopyController(IFileProvider fileProvider)
+        public CopyController(IFileProvider fileProvider, IFileOptions options)
         {
             _fileService = fileProvider;
-            _helper = new MoveHelper(_fileService);
+            _helper = new MoveHelper(_fileService, options);
         }
         
         [HttpHead]

--- a/src/Microsoft.IIS.Administration.Files/Controllers/CopyController.cs
+++ b/src/Microsoft.IIS.Administration.Files/Controllers/CopyController.cs
@@ -53,7 +53,7 @@ namespace Microsoft.IIS.Administration.Files
                 throw new NotFoundException("parent");
             }
 
-            var src = fileType == FileType.File ? _fileService.GetFile(fileId.PhysicalPath) : _fileService.GetDirectory(fileId.PhysicalPath);
+            IFileInfo src = fileType == FileType.File ? _fileService.GetFile(fileId.PhysicalPath) : _fileService.GetDirectory(fileId.PhysicalPath);
 
             string destPath = Path.Combine(parentId.PhysicalPath, name == null ? src.Name : name);
 
@@ -64,6 +64,7 @@ namespace Microsoft.IIS.Administration.Files
             if (fileType == FileType.File && _fileService.DirectoryExists(destPath) || fileType == FileType.Directory && _fileService.FileExists(destPath)) {
                 throw new AlreadyExistsException("name");
             }
+
 
             MoveOperation copy = InitiateCopy(src, destPath);
 

--- a/src/Microsoft.IIS.Administration.Files/Controllers/CopyController.cs
+++ b/src/Microsoft.IIS.Administration.Files/Controllers/CopyController.cs
@@ -18,13 +18,12 @@ namespace Microsoft.IIS.Administration.Files
         private IFileProvider _fileService;
         private static ConcurrentDictionary<string, MoveOperation> _copies = new ConcurrentDictionary<string, MoveOperation>();
 
-        public CopyController(IFileProvider fileProvider, IFileOptions options)
+        public CopyController(IFileProvider fileProvider)
         {
             _fileService = fileProvider;
-            _helper = new MoveHelper(_fileService, options);
+            _helper = new MoveHelper(_fileService);
         }
         
-        [HttpHead]
         [HttpPatch]
         [HttpPut]
         public IActionResult NotAllowed()

--- a/src/Microsoft.IIS.Administration.Files/Controllers/FilesController.cs
+++ b/src/Microsoft.IIS.Administration.Files/Controllers/FilesController.cs
@@ -29,7 +29,7 @@ namespace Microsoft.IIS.Administration.Files
         {
             _options = options;
             _provider = fileProvider;
-            _helper = new FilesHelper(fileProvider);
+            _helper = new FilesHelper(fileProvider, options);
         }
 
         [HttpHead]

--- a/src/Microsoft.IIS.Administration.Files/Controllers/MoveController.cs
+++ b/src/Microsoft.IIS.Administration.Files/Controllers/MoveController.cs
@@ -18,13 +18,12 @@ namespace Microsoft.IIS.Administration.Files
         private IFileProvider _fileService;
         private static ConcurrentDictionary<string, MoveOperation> _moves = new ConcurrentDictionary<string, MoveOperation>();
 
-        public MoveController(IFileProvider fileProvider, IFileOptions options)
+        public MoveController(IFileProvider fileProvider)
         {
             _fileService = fileProvider;
-            _helper = new MoveHelper(_fileService, options);
+            _helper = new MoveHelper(_fileService);
         }
-
-        [HttpHead]
+        
         [HttpPatch]
         [HttpPut]
         public IActionResult NotAllowed()

--- a/src/Microsoft.IIS.Administration.Files/Controllers/MoveController.cs
+++ b/src/Microsoft.IIS.Administration.Files/Controllers/MoveController.cs
@@ -18,10 +18,10 @@ namespace Microsoft.IIS.Administration.Files
         private IFileProvider _fileService;
         private static ConcurrentDictionary<string, MoveOperation> _moves = new ConcurrentDictionary<string, MoveOperation>();
 
-        public MoveController(IFileProvider fileProvider)
+        public MoveController(IFileProvider fileProvider, IFileOptions options)
         {
             _fileService = fileProvider;
-            _helper = new MoveHelper(_fileService);
+            _helper = new MoveHelper(_fileService, options);
         }
 
         [HttpHead]

--- a/src/Microsoft.IIS.Administration.Files/Copy/MoveHelper.cs
+++ b/src/Microsoft.IIS.Administration.Files/Copy/MoveHelper.cs
@@ -133,7 +133,10 @@ namespace Microsoft.IIS.Administration.Files
         }
 
         public MoveOperation Move(IFileInfo source, string dest, bool copy)
-        {            
+        {
+            _fileService.EnsureAccess(source.Path, copy ? FileAccess.Read : FileAccess.ReadWrite);
+            _fileService.EnsureAccess(dest, FileAccess.Write);
+
             if (source.Type == FileType.File) {
                 return MoveFile(source, dest, copy);
             }

--- a/src/Microsoft.IIS.Administration.Files/Copy/MoveHelper.cs
+++ b/src/Microsoft.IIS.Administration.Files/Copy/MoveHelper.cs
@@ -18,10 +18,10 @@ namespace Microsoft.IIS.Administration.Files
         private IFileProvider _fileService;
         private FilesHelper _filesHelper;
 
-        public MoveHelper(IFileProvider fileService, IFileOptions options)
+        public MoveHelper(IFileProvider fileService)
         {
             _fileService = fileService;
-            _filesHelper = new FilesHelper(_fileService, options);
+            _filesHelper = new FilesHelper(_fileService);
         }
 
         public static string GetLocation(string id, bool copy)

--- a/src/Microsoft.IIS.Administration.Files/Copy/MoveHelper.cs
+++ b/src/Microsoft.IIS.Administration.Files/Copy/MoveHelper.cs
@@ -18,10 +18,10 @@ namespace Microsoft.IIS.Administration.Files
         private IFileProvider _fileService;
         private FilesHelper _filesHelper;
 
-        public MoveHelper(IFileProvider fileService)
+        public MoveHelper(IFileProvider fileService, IFileOptions options)
         {
             _fileService = fileService;
-            _filesHelper = new FilesHelper(_fileService);
+            _filesHelper = new FilesHelper(_fileService, options);
         }
 
         public static string GetLocation(string id, bool copy)

--- a/src/Microsoft.IIS.Administration.Files/Copy/MoveOperation.cs
+++ b/src/Microsoft.IIS.Administration.Files/Copy/MoveOperation.cs
@@ -51,7 +51,7 @@ namespace Microsoft.IIS.Administration.Files
                     _totalSize = Source.Exists ? Source.Size : 0;
                 }
                 else {
-                    _totalSize = Source.Exists ? Directory.EnumerateFiles(Source.Path, "*", SearchOption.AllDirectories).Aggregate(0L, (prev, f) => prev + f.Length) : 0;
+                    _totalSize = Source.Exists ? _fileProvider.GetFiles(Source.Path, "*", SearchOption.AllDirectories).Aggregate(0L, (prev, f) => prev + f.Size) : 0;
                 }
 
                 return _totalSize;

--- a/src/Microsoft.IIS.Administration.Files/Downloads/Download.cs
+++ b/src/Microsoft.IIS.Administration.Files/Downloads/Download.cs
@@ -7,7 +7,7 @@ namespace Microsoft.IIS.Administration.Files
     using Core.Utils;
     using System.Security.Cryptography;
 
-    public class Download
+    class Download : IDownload
     {
         internal Download()
         {

--- a/src/Microsoft.IIS.Administration.Files/Downloads/DownloadService.cs
+++ b/src/Microsoft.IIS.Administration.Files/Downloads/DownloadService.cs
@@ -11,7 +11,7 @@ namespace Microsoft.IIS.Administration.Files
     class DownloadService : IDownloadService
     {
         private const int DEFAULT_DOWNLOAD_TIMEOUT = 5000; // milliseconds
-        private Dictionary<string, Download> _downloads = new Dictionary<string, Download>();
+        private Dictionary<string, IDownload> _downloads = new Dictionary<string, IDownload>();
         private IMemoryCache _cache;
 
         public DownloadService(IMemoryCache cache)
@@ -23,7 +23,7 @@ namespace Microsoft.IIS.Administration.Files
             _cache = cache;
         }
 
-        public Download Create(string physicalPath, int? timeout = null)
+        public IDownload Create(string physicalPath, int? timeout = null)
         {
             if (physicalPath == null) {
                 throw new ArgumentNullException(nameof(physicalPath));
@@ -44,9 +44,9 @@ namespace Microsoft.IIS.Administration.Files
             _downloads.Remove(id);
         }
 
-        public Download Get(string id)
+        public IDownload Get(string id)
         {
-            Download dl = null;
+            IDownload dl = null;
             _cache.TryGetValue(id, out dl);
             return dl;
         }

--- a/src/Microsoft.IIS.Administration.Files/FileRedirectService.cs
+++ b/src/Microsoft.IIS.Administration.Files/FileRedirectService.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+
+namespace Microsoft.IIS.Administration.Files
+{
+    using System;
+    using System.Collections.Generic;
+
+    public class FileRedirectService : IFileRedirectService
+    {
+        private Dictionary<string, IRedirect> _redirects = new Dictionary<string, IRedirect>();
+
+        public void AddRedirect(string fileName, Func<string> redirectBuilder, bool permanent)
+        {
+            _redirects.Add(fileName.ToLower(), new Redirect {
+                Name = fileName.ToLower(),
+                To = redirectBuilder,
+                Permanent = permanent
+            });
+        }
+
+        public IRedirect GetRedirect(string fileName)
+        {
+            var key = fileName.ToLower();
+            return _redirects.ContainsKey(key) ? _redirects[key] : null;
+        }
+
+        private class Redirect : IRedirect
+        {
+            public string Name { get; set; }
+            public Func<string> To { get; set; }
+            public bool Permanent { get; set; }
+        }
+    }
+}

--- a/src/Microsoft.IIS.Administration.Files/Files/FilesHelper.cs
+++ b/src/Microsoft.IIS.Administration.Files/Files/FilesHelper.cs
@@ -497,7 +497,7 @@ namespace Microsoft.IIS.Administration.Files
         {
             object ret = null;
 
-            var parentPath = PathUtil.GetParentPath(physicalPath);
+            var parentPath = Path.GetDirectoryName(physicalPath);
 
             if (!string.IsNullOrEmpty(parentPath) && _fileProvider.IsAccessAllowed(parentPath, FileAccess.Read)) {
                 ret = DirectoryToJsonModelRef(_fileProvider.GetDirectory(parentPath), fields);

--- a/src/Microsoft.IIS.Administration.Files/Files/FilesHelper.cs
+++ b/src/Microsoft.IIS.Administration.Files/Files/FilesHelper.cs
@@ -16,10 +16,12 @@ namespace Microsoft.IIS.Administration.Files
         private static readonly Fields RefFields = new Fields("name", "id", "type", "physical_path");
 
         private IFileProvider _fileProvider;
+        private IFileOptions _options;
 
-        public FilesHelper(IFileProvider fileProvider)
+        public FilesHelper(IFileProvider fileProvider, IFileOptions options)
         {
             _fileProvider = fileProvider;
+            _options = options;
         }
 
         public object ToJsonModel(string physicalPath, Fields fields = null, bool full = true)
@@ -102,6 +104,17 @@ namespace Microsoft.IIS.Administration.Files
             // id
             if (fields.Exists("id")) {
                 obj.id = fileId.Uuid;
+            }
+
+            //
+            // alias
+            if (fields.Exists("alias") && _options != null) {
+                foreach (var location in _options.Locations) {
+                    if (location.Path.TrimEnd(PathUtil.SEPARATORS).Equals(info.Path.TrimEnd(PathUtil.SEPARATORS))) {
+                        obj.alias = location.Alias;
+                        break;
+                    }
+                }
             }
 
             //
@@ -200,6 +213,17 @@ namespace Microsoft.IIS.Administration.Files
             // id
             if (fields.Exists("id")) {
                 obj.id = fileId.Uuid;
+            }
+
+            //
+            // alias
+            if (fields.Exists("alias") && _options != null) {
+                foreach (var location in _options.Locations) {
+                    if (location.Path.TrimEnd(PathUtil.SEPARATORS).Equals(info.Path.TrimEnd(PathUtil.SEPARATORS))) {
+                        obj.alias = location.Alias;
+                        break;
+                    }
+                }
             }
 
             //

--- a/src/Microsoft.IIS.Administration.Files/Files/FilesHelper.cs
+++ b/src/Microsoft.IIS.Administration.Files/Files/FilesHelper.cs
@@ -16,12 +16,10 @@ namespace Microsoft.IIS.Administration.Files
         private static readonly Fields RefFields = new Fields("name", "id", "type", "physical_path");
 
         private IFileProvider _fileProvider;
-        private IFileOptions _options;
 
-        public FilesHelper(IFileProvider fileProvider, IFileOptions options)
+        public FilesHelper(IFileProvider fileProvider)
         {
             _fileProvider = fileProvider;
-            _options = options;
         }
 
         public object ToJsonModel(string physicalPath, Fields fields = null, bool full = true)
@@ -108,8 +106,8 @@ namespace Microsoft.IIS.Administration.Files
 
             //
             // alias
-            if (fields.Exists("alias") && _options != null) {
-                foreach (var location in _options.Locations) {
+            if (fields.Exists("alias")) {
+                foreach (var location in _fileProvider.Options.Locations) {
                     if (location.Path.TrimEnd(PathUtil.SEPARATORS).Equals(info.Path.TrimEnd(PathUtil.SEPARATORS))) {
                         obj.alias = location.Alias;
                         break;
@@ -217,8 +215,8 @@ namespace Microsoft.IIS.Administration.Files
 
             //
             // alias
-            if (fields.Exists("alias") && _options != null) {
-                foreach (var location in _options.Locations) {
+            if (fields.Exists("alias")) {
+                foreach (var location in _fileProvider.Options.Locations) {
                     if (location.Path.TrimEnd(PathUtil.SEPARATORS).Equals(info.Path.TrimEnd(PathUtil.SEPARATORS))) {
                         obj.alias = location.Alias;
                         break;
@@ -421,7 +419,7 @@ namespace Microsoft.IIS.Administration.Files
 
             if (model.name != null) {
 
-                string name = DynamicHelper.Value(model.name);
+                string name = DynamicHelper.Value(model.name).Trim();
 
                 if (!PathUtil.IsValidFileName(name)) {
                     throw new ApiArgumentException("name");
@@ -463,13 +461,13 @@ namespace Microsoft.IIS.Administration.Files
             lastModified = DynamicHelper.To<DateTime>(model.last_modified);
 
             if (model.name != null) {
-                string name = DynamicHelper.Value(model.name);
+                string name = DynamicHelper.Value(model.name).Trim();
 
                 if (!PathUtil.IsValidFileName(name)) {
                     throw new ApiArgumentException("name");
                 }
 
-                var newPath = Path.Combine(directory.Parent.Path, name);
+                string newPath = Path.Combine(directory.Parent.Path, name);
 
                 if (!newPath.Equals(directoryPath, StringComparison.OrdinalIgnoreCase)) {
 

--- a/src/Microsoft.IIS.Administration.Files/Startup.cs
+++ b/src/Microsoft.IIS.Administration.Files/Startup.cs
@@ -8,7 +8,6 @@ namespace Microsoft.IIS.Administration.Files
     using Core;
     using Core.Http;
     using Extensions.Caching.Memory;
-    using Extensions.Configuration;
     using Extensions.DependencyInjection;
 
     public class Startup : BaseModule, IServiceCollectionAccessor
@@ -17,13 +16,9 @@ namespace Microsoft.IIS.Administration.Files
 
         public void Use(IServiceCollection services)
         {
-            services.AddSingleton<IDownloadService>(sp => {
-                return new DownloadService((IMemoryCache)sp.GetService(typeof(IMemoryCache)));
-            });
+            services.AddSingleton<IDownloadService>(sp => new DownloadService((IMemoryCache)sp.GetService(typeof(IMemoryCache))));
 
-            services.AddSingleton(sp => {
-                return FileOptions.FromConfiguration((IConfiguration)sp.GetService(typeof(IConfiguration)));
-            });
+            services.AddSingleton<IFileRedirectService>(sp => new FileRedirectService());
         }
 
         public override void Start()

--- a/src/Microsoft.IIS.Administration.Files/project.json
+++ b/src/Microsoft.IIS.Administration.Files/project.json
@@ -12,6 +12,7 @@
     }
   },
   "dependencies": {
+    "Microsoft.AspNetCore.StaticFiles": "1.0.0",
     "Microsoft.IIS.Administration.Files.Core": "1.0.0-*"
   }
 }

--- a/src/Microsoft.IIS.Administration.Files/project.json
+++ b/src/Microsoft.IIS.Administration.Files/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Microsoft.IIS.Administration.Files Class Library",
   "authors": [ "Microsoft" ],
   "frameworks": {
@@ -13,6 +13,6 @@
   },
   "dependencies": {
     "Microsoft.AspNetCore.StaticFiles": "1.0.0",
-    "Microsoft.IIS.Administration.Files.Core": "1.0.0-*"
+    "Microsoft.IIS.Administration.Files.Core": "1.0.1"
   }
 }

--- a/src/Microsoft.IIS.Administration.WebServer.Files/Controllers/WsFilesController.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Files/Controllers/WsFilesController.cs
@@ -23,10 +23,10 @@ namespace Microsoft.IIS.Administration.WebServer.Files
         private IFileProvider _fileProvider;
         private FilesHelper _filesHelper;
 
-        public WsFilesController(IFileProvider fileProvider, IFileOptions options)
+        public WsFilesController(IFileProvider fileProvider)
         {
             _fileProvider = fileProvider;
-            _filesHelper = new FilesHelper(fileProvider, options);
+            _filesHelper = new FilesHelper(fileProvider);
         }
 
         [HttpDelete]

--- a/src/Microsoft.IIS.Administration.WebServer.Files/Controllers/WsFilesController.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Files/Controllers/WsFilesController.cs
@@ -23,10 +23,10 @@ namespace Microsoft.IIS.Administration.WebServer.Files
         private IFileProvider _fileProvider;
         private FilesHelper _filesHelper;
 
-        public WsFilesController(IFileProvider fileProvider)
+        public WsFilesController(IFileProvider fileProvider, IFileOptions options)
         {
             _fileProvider = fileProvider;
-            _filesHelper = new FilesHelper(fileProvider);
+            _filesHelper = new FilesHelper(fileProvider, options);
         }
 
         [HttpDelete]

--- a/src/Microsoft.IIS.Administration.WebServer.Files/FilesHelper.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Files/FilesHelper.cs
@@ -20,10 +20,10 @@ namespace Microsoft.IIS.Administration.WebServer.Files
         private IFileProvider _fileProvider;
         private Administration.Files.FilesHelper _filesHelper;
 
-        public FilesHelper(IFileProvider fileProvider, IFileOptions options)
+        public FilesHelper(IFileProvider fileProvider)
         {
             _fileProvider = fileProvider;
-            _filesHelper = new Administration.Files.FilesHelper(_fileProvider, options);
+            _filesHelper = new Administration.Files.FilesHelper(_fileProvider);
         }
 
         public object ToJsonModel(Site site, string path, Fields fields = null, bool full = true)

--- a/src/Microsoft.IIS.Administration.WebServer.Files/FilesHelper.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Files/FilesHelper.cs
@@ -20,10 +20,10 @@ namespace Microsoft.IIS.Administration.WebServer.Files
         private IFileProvider _fileProvider;
         private Administration.Files.FilesHelper _filesHelper;
 
-        public FilesHelper(IFileProvider fileProvider)
+        public FilesHelper(IFileProvider fileProvider, IFileOptions options)
         {
             _fileProvider = fileProvider;
-            _filesHelper = new Administration.Files.FilesHelper(_fileProvider);
+            _filesHelper = new Administration.Files.FilesHelper(_fileProvider, options);
         }
 
         public object ToJsonModel(Site site, string path, Fields fields = null, bool full = true)

--- a/src/Microsoft.IIS.Administration.WebServer.HttpRequestTracing/Controllers/RequestTracesController.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.HttpRequestTracing/Controllers/RequestTracesController.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+
+namespace Microsoft.IIS.Administration.WebServer.HttpRequestTracing
+{
+    using AspNetCore.Mvc;
+    using Core;
+    using Core.Http;
+    using Files;
+    using Sites;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Web.Administration;
+
+    public class RequestTracesController : ApiBaseController
+    {
+        private IFileProvider _provider;
+
+        public RequestTracesController(IFileProvider provider)
+        {
+            _provider = provider;
+        }
+
+        [HttpGet]
+        [ResourceInfo(Name = Defines.TracesName)]
+        public async Task<object> Get()
+        {
+            string hrtUuid = Context.Request.Query[Defines.IDENTIFIER];
+
+            if (string.IsNullOrEmpty(hrtUuid)) {
+                return NotFound();
+            }
+
+            var id = new HttpRequestTracingId(hrtUuid);
+            Site site = id?.SiteId == null ? null : SiteHelper.GetSite(id.SiteId.Value);
+
+            if (site == null) {
+                return NotFound();
+            }
+
+            var helper = new TracesHelper(_provider, site);
+
+            IEnumerable<TraceInfo> traces = await helper.GetTraces();
+
+            Context.Response.SetItemsCount(traces.Count());
+
+            return new {
+                traces = traces.Select(t => helper.ToJsonModel(t, Context.Request.GetFields()))
+            };
+        }
+
+        [HttpGet]
+        [ResourceInfo(Name = Defines.TraceName)]
+        public async Task<object> Get(string id)
+        {
+            TraceId traceId = new TraceId(id);
+            Site site = SiteHelper.GetSite(traceId.SiteId);
+
+            if (site == null) {
+                return NotFound();
+            }
+
+            var helper = new TracesHelper(_provider, site);
+
+            TraceInfo trace = await helper.GetTrace(traceId.Name);
+
+            if (trace == null) {
+                return NotFound();
+            }
+
+            return helper.ToJsonModel(trace, Context.Request.GetFields());
+        }
+    }
+}

--- a/src/Microsoft.IIS.Administration.WebServer.HttpRequestTracing/Defines.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.HttpRequestTracing/Defines.cs
@@ -12,6 +12,7 @@ namespace Microsoft.IIS.Administration.WebServer.HttpRequestTracing
         private const string ENDPOINT = "http-request-tracing";
         private const string PROVIDERS_ENDPOINT = "providers";
         private const string RULES_ENDPOINT = "rules";
+        private const string TRACES_ENDPOINT = "traces";
 
         public const string HttpRequestTracingName = "Microsoft.WebServer.HttpRequestTracing";
         public static readonly string PATH = $"{WebServer.Defines.PATH}/{ENDPOINT}";
@@ -29,5 +30,11 @@ namespace Microsoft.IIS.Administration.WebServer.HttpRequestTracing
         public static readonly string RULES_PATH = $"{PATH}/{RULES_ENDPOINT}";
         public static readonly ResDef RulesResource = new ResDef("rules", new Guid("FE6059CD-DF4D-47E9-AAB3-5C380874E323"), RULES_ENDPOINT);
         public const string RULES_IDENTIFIER = "rule.id";
+
+        public const string TracesName = "Microsoft.WebServer.HttpRequestTracing.Traces";
+        public const string TraceName = "Microsoft.WebServer.HttpRequestTracing.Trace";
+        public static readonly string TRACES_PATH = $"{PATH}/{TRACES_ENDPOINT}";
+        public static readonly ResDef TracesResource = new ResDef("traces", new Guid("3A103124-E4AF-49D9-A379-949F314A89F1"), TRACES_ENDPOINT);
+        public const string TRACES_IDENTIFIER = "trace.id";
     }
 }

--- a/src/Microsoft.IIS.Administration.WebServer.HttpRequestTracing/Helpers/TracesHelper.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.HttpRequestTracing/Helpers/TracesHelper.cs
@@ -1,0 +1,183 @@
+﻿namespace Microsoft.IIS.Administration.WebServer.HttpRequestTracing
+{
+    using Core;
+    using Core.Utils;
+    using Files;
+    using System;
+    using System.Collections.Generic;
+    using System.Dynamic;
+    using System.IO;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using System.Xml;
+    using Web.Administration;
+
+    sealed class TracesHelper
+    {
+        private static readonly Fields RefFields = new Fields("url", "id", "http_status", "method", "time_taken");
+
+        private static readonly XmlReaderSettings _xmlReaderSettings = new XmlReaderSettings() {
+            Async = true
+        };
+
+        private IFileProvider _provider;
+        private Site _site;
+
+        public TracesHelper(IFileProvider provider, Site site)
+        {
+            _provider = provider;
+            _site = site;
+        }
+
+        public async Task<IEnumerable<TraceInfo>> GetTraces()
+        {
+            IEnumerable<IFileInfo> files = null;
+            string dir = _site.TraceFailedRequestsLogging.Directory;
+            string path = string.IsNullOrEmpty(dir) ? null : Path.Combine(PathUtil.GetFullPath(dir), "W3SVC" + _site.Id);
+
+            if (path != null) {
+                files = _provider.GetFiles(path, "*.xml");
+            }
+
+            return await Task.WhenAll(files.Select(f => GetTraceInternal(f)));
+        }
+
+        public async Task<TraceInfo> GetTrace(string id)
+        {
+            return (await GetTraces()).FirstOrDefault(t => t.File.Name.Equals(id, StringComparison.OrdinalIgnoreCase));
+        }
+
+        public object ToJsonModel(TraceInfo trace, Fields fields = null, bool full = true)
+        {
+            TraceId traceId = new TraceId(_site.Id, trace.File.Name);
+
+            if (fields == null) {
+                fields = Fields.All;
+            }
+
+            dynamic obj = new ExpandoObject();
+
+            //
+            // id
+            obj.id = traceId.Uuid;
+
+            //
+            // url
+            if (fields.Exists("url") && !string.IsNullOrEmpty(trace.Url)) {
+                obj.url = trace.Url;
+            }
+
+            //
+            // method
+            if (fields.Exists("method") && !string.IsNullOrEmpty(trace.Method)) {
+                obj.method = trace.Method;
+            }
+
+            //
+            // status_code
+            if (fields.Exists("status_code") && trace.StatusCode > 0) {
+                obj.status_code = trace.StatusCode;
+            }
+
+            //
+            // date
+            if (fields.Exists("date")) {
+                obj.date = trace.Date;
+            }
+
+            //
+            // time_taken
+            if (fields.Exists("time_taken")) {
+                obj.time_taken = trace.TimeTaken;
+            }
+
+            //
+            // process_id
+            if (fields.Exists("process_id") && !string.IsNullOrEmpty(trace.ProcessId)) {
+                obj.process_id = trace.ProcessId;
+            }
+
+            //
+            // activity_id
+            if (fields.Exists("activity_id") && !string.IsNullOrEmpty(trace.ActivityId)) {
+                obj.activity_id = trace.ActivityId;
+            }
+
+            //
+            // file_info
+            if (fields.Exists("file_info")) {
+                obj.file_info = new FilesHelper(_provider).ToJsonModelRef(trace.File, fields.Filter("file_info"));
+            }
+
+            //
+            // request_tracing
+            if (fields.Exists("request_tracing")) {
+                obj.request_tracing = Helper.ToJsonModelRef(_site, "/");
+            }
+
+            return Core.Environment.Hal.Apply(Defines.TracesResource.Guid, obj, full); ;
+        }
+
+        public object ToJsonModelRef(TraceInfo trace, Fields fields = null)
+        {
+            if (fields == null || !fields.HasFields) {
+                return ToJsonModel(trace, RefFields, false);
+            }
+            else {
+                return ToJsonModel(trace, fields, false);
+            }
+        }
+
+        public static string GetLocation(string id)
+        {
+            return $"/{Defines.TRACES_PATH}/{id}";
+        }
+
+        private Task<TraceInfo> GetTraceInternal(IFileInfo trace)
+        {
+            return ParseTrace(trace);
+        }
+
+        private async Task<TraceInfo> ParseTrace(IFileInfo trace)
+        {
+            TraceInfo info = null;
+
+
+            using (var stream = _provider.GetFileStream(trace.Path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            using (var reader = XmlReader.Create(stream, _xmlReaderSettings)) {
+                try {
+
+                    while (await reader.ReadAsync()) {
+                        if (reader.NodeType == XmlNodeType.Element && reader.Name.Equals("failedRequest")) {
+                            
+                            info = new TraceInfo() {
+                                File = trace,
+                                Url = reader.GetAttribute("url"),
+                                Method = reader.GetAttribute("verb"),
+                                Date = trace.Created,
+                                ProcessId = reader.GetAttribute("processId"),
+                                ActivityId = reader.GetAttribute("activityId")
+                            };
+
+                            float.TryParse(reader.GetAttribute("triggerStatusCode"), out info.StatusCode);
+                            int.TryParse(reader.GetAttribute("timeTaken"), out info.TimeTaken);
+                            
+                            break;
+                        }
+                    }
+                }
+                catch(XmlException) {
+                    // Ignore malformatted XML
+                }
+            }
+            
+            if (info == null) {
+                info = new TraceInfo() {
+                    File = trace
+                };
+            }
+
+            return info;
+        }
+    }
+}

--- a/src/Microsoft.IIS.Administration.WebServer.HttpRequestTracing/Startup.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.HttpRequestTracing/Startup.cs
@@ -21,6 +21,7 @@ namespace Microsoft.IIS.Administration.WebServer.HttpRequestTracing
             ConfigureHttpRequestTracing();
             ConfigureProviders();
             ConfigureRules();
+            ConfigureTraces();
         }
 
         private void ConfigureXsl()
@@ -83,6 +84,15 @@ namespace Microsoft.IIS.Administration.WebServer.HttpRequestTracing
             Environment.Hal.ProvideLink(Defines.RulesResource.Guid, "self", r => new { href = RulesHelper.GetLocation(r.id) });
 
             Environment.Hal.ProvideLink(Defines.Resource.Guid, Defines.RulesResource.Name, hrt => new { href = $"/{Defines.RULES_PATH}?{Defines.IDENTIFIER}={hrt.id}" });
+        }
+
+        private void ConfigureTraces()
+        {
+            Environment.Host.RouteBuilder.MapWebApiRoute(Defines.TracesResource.Guid, $"{ Defines.TRACES_PATH}/{{id?}}", new { controller = "RequestTraces" });
+
+            Environment.Hal.ProvideLink(Defines.TracesResource.Guid, "self", r => new { href = TracesHelper.GetLocation(r.id) });
+
+            Environment.Hal.ProvideLink(Defines.Resource.Guid, Defines.TracesResource.Name, hrt => new { href = $"/{Defines.TRACES_PATH}?{Defines.IDENTIFIER}={hrt.id}" });
         }
     }
 }

--- a/src/Microsoft.IIS.Administration.WebServer.HttpRequestTracing/Startup.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.HttpRequestTracing/Startup.cs
@@ -6,8 +6,10 @@ namespace Microsoft.IIS.Administration.WebServer.HttpRequestTracing
 {
     using Applications;
     using AspNetCore.Builder;
+    using AspNetCore.Hosting;
     using Core;
     using Core.Http;
+    using Files;
     using Sites;
     using Web.Administration;
 
@@ -15,9 +17,24 @@ namespace Microsoft.IIS.Administration.WebServer.HttpRequestTracing
     {
         public override void Start()
         {
+            ConfigureXsl();
             ConfigureHttpRequestTracing();
             ConfigureProviders();
             ConfigureRules();
+        }
+
+        private void ConfigureXsl()
+        {
+            var services = Environment.Host.ApplicationBuilder.ApplicationServices;
+            var redirecter = (IFileRedirectService) services.GetService(typeof(IFileRedirectService));
+
+            if (redirecter != null) {
+                var hostingEnv = (IHostingEnvironment)services.GetService(typeof(IHostingEnvironment));
+                var configProvider = (IApplicationHostConfigProvider)services.GetService(typeof(IApplicationHostConfigProvider));
+                var xslLocator = new XslLocator(hostingEnv, configProvider);
+
+                redirecter.AddRedirect("freb.xsl", () => xslLocator.GetPath(), true);
+            }
         }
 
         private void ConfigureHttpRequestTracing()

--- a/src/Microsoft.IIS.Administration.WebServer.HttpRequestTracing/TraceId.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.HttpRequestTracing/TraceId.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+
+namespace Microsoft.IIS.Administration.WebServer.HttpRequestTracing
+{
+    using System;
+
+    public class TraceId
+    {
+        private const string PURPOSE = "WebServer.HttpRequestTracing.Trace";
+        private const char DELIMITER = '\n';
+        
+        private const uint SITE_ID_INDEX = 0;
+        private const uint NAME_INDEX = 1;
+
+        public long SiteId { get; private set; }
+        public string Name { get; private set; }
+        public string Uuid { get; private set; }
+
+        public TraceId(string uuid)
+        {
+            if (string.IsNullOrEmpty(uuid)) {
+                throw new ArgumentNullException("uuid");
+            }
+
+            var info = Core.Utils.Uuid.Decode(uuid, PURPOSE).Split(DELIMITER);
+
+            this.Name = info[NAME_INDEX];
+            this.SiteId = long.Parse(info[SITE_ID_INDEX]);
+            this.Uuid = uuid;
+        }
+
+        public TraceId(long siteId, string name)
+        {
+            this.SiteId = siteId;
+            this.Name = name;
+            this.Uuid = Core.Utils.Uuid.Encode(this.Name + DELIMITER + this.SiteId.ToString(), PURPOSE);
+        }
+    }
+}

--- a/src/Microsoft.IIS.Administration.WebServer.HttpRequestTracing/TraceInfo.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.HttpRequestTracing/TraceInfo.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+
+namespace Microsoft.IIS.Administration.WebServer.HttpRequestTracing
+{
+    using Files;
+    using System;
+
+    class TraceInfo
+    {
+        public IFileInfo File;
+        public string Url;
+        public string Method;
+        public float StatusCode;
+        public DateTime Date;
+        public int TimeTaken;
+        public string ProcessId;
+        public string ActivityId;
+    }
+}

--- a/src/Microsoft.IIS.Administration.WebServer.HttpRequestTracing/XslLocator.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.HttpRequestTracing/XslLocator.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+
+namespace Microsoft.IIS.Administration.WebServer.HttpRequestTracing
+{
+    using AspNetCore.Hosting;
+    using Serilog;
+    using System;
+    using System.IO;
+    using System.Linq;
+    using Web.Administration;
+
+    sealed class XslLocator
+    {
+        private const string _path = "static/Microsoft.IIS.Administration.WebServer.HttpRequestTracing/freb.xsl";
+        private string _physicalPath;
+        private IApplicationHostConfigProvider _configProvider;
+
+        public XslLocator(IHostingEnvironment env, IApplicationHostConfigProvider configProvider)
+        {
+            _physicalPath = Path.Combine(env.WebRootPath, _path);
+            _configProvider = configProvider;
+        }
+
+        public string GetPath()
+        {
+            if (!File.Exists(_physicalPath)) {
+                CopyXsl();
+            }
+
+            return "/" + _path;
+        }
+
+        private void CopyXsl()
+        {
+            using (var sm = new ServerManager(true, _configProvider?.Path)) {
+                foreach (var site in sm.Sites) {
+                    try {
+                        string dir = Environment.ExpandEnvironmentVariables(site.TraceFailedRequestsLogging.Directory);
+                        if (Directory.Exists(dir)) {
+                            string file = Directory.GetFiles(dir, "freb.xsl", SearchOption.AllDirectories).FirstOrDefault();
+                            if (string.IsNullOrEmpty(file)) {
+                                continue;
+                            }
+                            Directory.CreateDirectory(Path.GetDirectoryName(_physicalPath));
+                            File.Copy(file, _physicalPath, true);
+                            break;
+                        }
+                    }
+                    catch (Exception e) {
+                        Log.Error(e, "Copy freb.xsl failed.");
+                        continue;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.IIS.Administration.WebServer.HttpRequestTracing/project.json
+++ b/src/Microsoft.IIS.Administration.WebServer.HttpRequestTracing/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Microsoft.IIS.Administration.WebServer.HttpRequestTracing Class Library",
   "authors": [ "Microsoft" ],
   "frameworks": {

--- a/src/Microsoft.IIS.Administration.WebServer/ApplicationHostConfigProvider.cs
+++ b/src/Microsoft.IIS.Administration.WebServer/ApplicationHostConfigProvider.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+
+namespace Microsoft.IIS.Administration.WebServer
+{
+    class ApplicationHostConfigProvider : IApplicationHostConfigProvider
+    {
+        public ApplicationHostConfigProvider(string path)
+        {
+            Path = path;
+        }
+
+        public string Path { get; private set; }
+    }
+}

--- a/src/Microsoft.IIS.Administration.WebServer/Controllers/TransactionsController.cs
+++ b/src/Microsoft.IIS.Administration.WebServer/Controllers/TransactionsController.cs
@@ -12,6 +12,12 @@ namespace Microsoft.IIS.Administration.WebServer
 
     public class TransactionsController : ApiBaseController
     {
+        private IApplicationHostConfigProvider _configProvider;
+
+        public TransactionsController(IApplicationHostConfigProvider configProvider) {
+            _configProvider = configProvider;
+        }
+
         [HttpGet]
         [ResourceInfo(Name = Defines.TransactionsName)]
         public object Get()
@@ -43,7 +49,7 @@ namespace Microsoft.IIS.Administration.WebServer
         [ResourceInfo(Name = Defines.TransactionName)]
         public object Post()
         {
-            Transaction transaction = Store.BeginTransaction();
+            Transaction transaction = Store.BeginTransaction(_configProvider);
 
             //
             // Set the current management unit

--- a/src/Microsoft.IIS.Administration.WebServer/IApplicationHostConfigProvider.cs
+++ b/src/Microsoft.IIS.Administration.WebServer/IApplicationHostConfigProvider.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 
-namespace Microsoft.IIS.Administration.Files
+namespace Microsoft.IIS.Administration.WebServer
 {
-    using System.Collections.Generic;
-
-    public interface IFileOptions
+    public interface IApplicationHostConfigProvider
     {
-        IList<ILocation> Locations { get; set; }
+        string Path { get; }
     }
 }

--- a/src/Microsoft.IIS.Administration.WebServer/ManagementUnit/MgmtUnit.cs
+++ b/src/Microsoft.IIS.Administration.WebServer/ManagementUnit/MgmtUnit.cs
@@ -9,10 +9,13 @@ namespace Microsoft.IIS.Administration.WebServer
     using Web.Administration;
 
     class MgmtUnit : IManagementUnit {
+        private IApplicationHostConfigProvider _provider;
+
         public ServerManager ServerManager { get; private set; }
 
-        public MgmtUnit()
+        public MgmtUnit(IApplicationHostConfigProvider provider)
         {
+            _provider = provider;
             this.ServerManager = new ServerManager(ApplicationHostConfigPath);
         }
 
@@ -22,7 +25,7 @@ namespace Microsoft.IIS.Administration.WebServer
             get {
                 //
                 // At the moment support global applicationHost.config
-                return null;
+                return _provider?.Path;
             }
         }
 

--- a/src/Microsoft.IIS.Administration.WebServer/Middleware/Injector.cs
+++ b/src/Microsoft.IIS.Administration.WebServer/Middleware/Injector.cs
@@ -13,10 +13,12 @@ namespace Microsoft.IIS.Administration.WebServer
     {
         private RequestDelegate _next;
         private static readonly string WEBSERVER_PATH = "/" + Defines.PATH;
+        private IApplicationHostConfigProvider _confgProvider;
 
-        public Injector(RequestDelegate next)
+        public Injector(RequestDelegate next, IApplicationHostConfigProvider provider)
         {
             _next = next;
+            _confgProvider = provider;
         }
 
         public async Task Invoke(HttpContext context)
@@ -65,7 +67,7 @@ namespace Microsoft.IIS.Administration.WebServer
 
         private async Task ProceedNoTransaction(HttpContext context)
         {
-            using (var mu = new MgmtUnit()) {
+            using (var mu = new MgmtUnit(_confgProvider)) {
                 context.SetManagementUnit(mu);
                 try {
                     await _next(context);

--- a/src/Microsoft.IIS.Administration.WebServer/Startup.cs
+++ b/src/Microsoft.IIS.Administration.WebServer/Startup.cs
@@ -7,10 +7,16 @@ namespace Microsoft.IIS.Administration.WebServer
     using AspNetCore.Builder;
     using Core;
     using Core.Http;
+    using Extensions.DependencyInjection;
 
-    public class Startup : BaseModule
+    public class Startup : BaseModule, IServiceCollectionAccessor
     {
         public Startup() { }
+
+        public void Use(IServiceCollection services)
+        {
+            services.AddSingleton<IApplicationHostConfigProvider>(sp => new ApplicationHostConfigProvider(null));
+        }
 
         public override void Start()
         {
@@ -24,7 +30,7 @@ namespace Microsoft.IIS.Administration.WebServer
             var router = Environment.Host.RouteBuilder;
             var hal = Environment.Hal;
 
-            app.UseMiddleware<Injector>();
+            app.UseMiddleware<Injector>(app.ApplicationServices.GetRequiredService<IApplicationHostConfigProvider>());
 
             router.MapWebApiRoute(Defines.Resource.Guid, $"{Defines.PATH}/{{id?}}", new { controller = "webserver" });
 

--- a/src/Microsoft.IIS.Administration.WebServer/Transactions/Store.cs
+++ b/src/Microsoft.IIS.Administration.WebServer/Transactions/Store.cs
@@ -5,7 +5,6 @@
 namespace Microsoft.IIS.Administration.WebServer
 {
     using AspNetCore.Http;
-    using Core;
     using System;
     using System.Threading;
 
@@ -20,7 +19,7 @@ namespace Microsoft.IIS.Administration.WebServer
 
         public static MgmtUnit ManagementUnit { get; set; }
 
-        public static Transaction BeginTransaction()
+        public static Transaction BeginTransaction(IApplicationHostConfigProvider provider)
         {
             lock (_lock) {
                 if (Transaction == null) {
@@ -30,7 +29,7 @@ namespace Microsoft.IIS.Administration.WebServer
                     _timer = new Timer(TimeoutCallback, null, TRANSACTION_IDLE_TIMEOUT, Timeout.Infinite);
 
                     
-                    ManagementUnit = new MgmtUnit();
+                    ManagementUnit = new MgmtUnit(provider);
                     Transaction = transaction;
                 }
             }

--- a/src/Microsoft.IIS.Administration/Errors/ErrorHandler.cs
+++ b/src/Microsoft.IIS.Administration/Errors/ErrorHandler.cs
@@ -83,8 +83,7 @@ namespace Microsoft.IIS.Administration {
             if (Log.Logger.IsEnabled(LogEventLevel.Error)) {
                 Task.Run(() => {
                     Log.Logger.Error($"{e.Message}{System.Environment.NewLine}\t{e.StackTrace}{System.Environment.NewLine}{System.Environment.NewLine}");
-                });
-                
+                });                
             }
         }
     }

--- a/src/Microsoft.IIS.Administration/Files/FileProviderExtensions.cs
+++ b/src/Microsoft.IIS.Administration/Files/FileProviderExtensions.cs
@@ -11,7 +11,9 @@ namespace Microsoft.IIS.Administration.Files
     {
         public static IServiceCollection AddFileProvider(this IServiceCollection services)
         {
-            services.AddSingleton<IAccessControl>((sp) => new AccessControl(sp.GetRequiredService<IConfiguration>()));
+            services.AddSingleton<IFileOptions>(sp => FileOptions.FromConfiguration(sp.GetRequiredService<IConfiguration>()));
+
+            services.AddSingleton<IAccessControl>((sp) => new AccessControl(sp.GetRequiredService<IFileOptions>()));
 
             services.AddSingleton<IFileProvider>((sp) => new FileProvider(sp.GetRequiredService<IAccessControl>()));
 

--- a/src/Microsoft.IIS.Administration/Files/FileProviderExtensions.cs
+++ b/src/Microsoft.IIS.Administration/Files/FileProviderExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.IIS.Administration.Files
 
             services.AddSingleton<IAccessControl>((sp) => new AccessControl(sp.GetRequiredService<IFileOptions>()));
 
-            services.AddSingleton<IFileProvider>((sp) => new FileProvider(sp.GetRequiredService<IAccessControl>()));
+            services.AddSingleton<IFileProvider>((sp) => new FileProvider(sp.GetRequiredService<IAccessControl>(), sp.GetRequiredService<IFileOptions>()));
 
             return services;
         }

--- a/src/Microsoft.IIS.Administration/project.json
+++ b/src/Microsoft.IIS.Administration/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.0.4",
   "commands": {
     "web": "Microsoft.AspNet.Server.Kestrel"
   },
@@ -31,7 +31,7 @@
     "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0",
     "Microsoft.AspNetCore.Diagnostics": "1.0.0",
-    "Microsoft.IIS.Administration.Files.Core": "1.0.0-*"
+    "Microsoft.IIS.Administration.Files.Core": "1.0.1"
   },
 
   "tools": {


### PR DESCRIPTION
This pull request adds the request tracing _traces_ API.

### Changes
* An HTTP request tracing _traces_ API has been added to provide summary information for a sites request tracing logs.
* The API now exposes IIS's freb.xsl file via _/downloads/freb.xl_ in response to #64 .
* Alias's are now properly transmitted with relevant _/api/files_ resources. #65 


### /api/webserver/request-tracing/http-request-tracing/traces

```
{
    "traces": [
        {
            "id": "m32IrS8gxJQGybnagJZoOA",
            "url": "http://localhost:80/",
            "method": "GET",
            "status_code": "304",
            "date": "2017-02-21T10:36:54.3711178-08:00",
            "time_taken": "140",
            "process_id": "10908",
            "activity_id": "{800004CF-0000-FD00-B63F-84710C7967BB}",
            "file_info": {
                "name": "fr000001.xml",
                "id": "xHKp6rdw00NDbXqZPnO8BAig2oeXUvLoRLGIIqfebcEt8y1XJUTWtTG5o4kuHl-9wFF4MxuM2DIqFUFz5n7ePQ",
                "type": "file",
                "physical_path": "C:\\inetpub\\logs\\FailedReqLogFiles\\W3SVC1\\fr000001.xml",
                "_links": {
                    "self": {
                        "href": "/api/files/xHKp6rdw00NDbXqZPnO8BAig2oeXUvLoRLGIIqfebcEt8y1XJUTWtTG5o4kuHl-9wFF4MxuM2DIqFUFz5n7ePQ"
                    }
                }
            },
            "request_tracing": {
                "id": "OhAX4SSyiIuj8WqSW1yWFw",
                "scope": "Default Web Site/",
                "_links": {
                    "self": {
                        "href": "/api/webserver/http-request-tracing/OhAX4SSyiIuj8WqSW1yWFw"
                    }
                }
            },
            "_links": {
                "self": {
                    "href": "/api/webserver/http-request-tracing/traces/m32IrS8gxJQGybnagJZoOA"
                }
            }
        }
    ]
}

```