### PR TITLE
Feature installation enhancements

### DIFF
--- a/src/Microsoft.IIS.Administration.WebServer.Authentication/Controllers/WinAuthController.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Authentication/Controllers/WinAuthController.cs
@@ -64,24 +64,9 @@ namespace Microsoft.IIS.Administration.WebServer.Authentication
             return WindowsAuthenticationHelper.ToJsonModel(site, winAuthId.Path);
         }
 
-        [HttpPost]
-        [Audit]
-        [ResourceInfo(Name = Defines.WindowsAuthenticationName)]
-        public async Task<object> Post()
-        {
-            if (WindowsAuthenticationHelper.IsFeatureEnabled()) {
-                throw new AlreadyExistsException(WindowsAuthenticationHelper.FEATURE_NAME);
-            }
-
-            await WindowsAuthenticationHelper.SetFeatureEnabled(true);
-
-            dynamic auth = WindowsAuthenticationHelper.ToJsonModel(null, null);
-            return Created(WindowsAuthenticationHelper.GetLocation(auth.id), auth);
-        }
-
         [HttpDelete]
         [Audit]
-        public async Task Delete(string id)
+        public void Delete(string id)
         {
             WinAuthId winAuthId = new WinAuthId(id);
 
@@ -92,10 +77,6 @@ namespace Microsoft.IIS.Administration.WebServer.Authentication
             if (site != null) {
                 WindowsAuthenticationHelper.GetSection(site, winAuthId.Path, ManagementUnit.ResolveConfigScope()).RevertToParent();
                 ManagementUnit.Current.Commit();
-            }
-
-            if (winAuthId.SiteId == null && WindowsAuthenticationHelper.IsFeatureEnabled()) {
-                await WindowsAuthenticationHelper.SetFeatureEnabled(false);
             }
         }
     }

--- a/src/Microsoft.IIS.Administration.WebServer.Authorization/Controller/AuthorizationController.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Authorization/Controller/AuthorizationController.cs
@@ -71,24 +71,9 @@ namespace Microsoft.IIS.Administration.WebServer.Authorization
             return authorization;
         }
 
-        [HttpPost]
-        [Audit]
-        [ResourceInfo(Name = Defines.AuthorizationName)]
-        public async Task<object> Post()
-        {
-            if (AuthorizationHelper.IsFeatureEnabled()) {
-                throw new AlreadyExistsException(AuthorizationHelper.FEATURE_NAME);
-            }
-
-            await AuthorizationHelper.SetFeatureEnabled(true);
-
-            dynamic auth = AuthorizationHelper.ToJsonModel(null, null);
-            return Created(AuthorizationHelper.GetLocation(auth.id), auth);
-        }
-
         [HttpDelete]
         [Audit]
-        public async Task Delete(string id)
+        public void Delete(string id)
         {
             AuthorizationId authId = new AuthorizationId(id);
 
@@ -100,10 +85,6 @@ namespace Microsoft.IIS.Administration.WebServer.Authorization
                 var section = AuthorizationHelper.GetSection(site, authId.Path, ManagementUnit.ResolveConfigScope());
                 section.RevertToParent();
                 ManagementUnit.Current.Commit();
-            }
-
-            if (authId.SiteId == null && AuthorizationHelper.IsFeatureEnabled()) {
-                await AuthorizationHelper.SetFeatureEnabled(false);
             }
         }
     }

--- a/src/Microsoft.IIS.Administration.WebServer.RequestMonitor/Controllers/RequestMonitoringController.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.RequestMonitor/Controllers/RequestMonitoringController.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+
+namespace Microsoft.IIS.Administration.WebServer.RequestMonitor
+{
+    using AspNetCore.Mvc;
+    using Core;
+    using Core.Http;
+    using System.Threading.Tasks;
+
+    public class RequestMonitoringController : ApiBaseController
+    {
+        [HttpGet]
+        [ResourceInfo(Name = Defines.MonitorName)]
+        [RequireGlobalModule(RequestHelper.MODULE, RequestHelper.DISPLAY_NAME)]
+        public object Get()
+        {
+            return LocationChanged(RequestHelper.GetLocation(), RequestHelper.FeatureToJsonModel());
+        }
+
+        [HttpGet]
+        [ResourceInfo(Name = Defines.MonitorName)]
+        [RequireGlobalModule(RequestHelper.MODULE, RequestHelper.DISPLAY_NAME)]
+        public object Get(string id)
+        {
+            RmId rmId = new RmId();
+
+            if (!rmId.Uuid.Equals(id)) {
+                return NotFound();
+            }
+
+            return RequestHelper.FeatureToJsonModel();
+        }
+
+        [HttpPost]
+        [Audit]
+        [ResourceInfo(Name = Defines.MonitorName)]
+        public async Task<object> Post()
+        {
+            if (RequestHelper.IsFeatureEnabled()) {
+                throw new AlreadyExistsException(RequestHelper.DISPLAY_NAME);
+            }
+
+            await RequestHelper.SetFeatureEnabled(true);
+
+            dynamic settings = RequestHelper.FeatureToJsonModel();
+            return Created(RequestHelper.GetLocation(), settings);
+        }
+
+        [HttpDelete]
+        [Audit]
+        public async Task Delete(string id)
+        {
+            RmId rmId = new RmId();
+
+            if (rmId.Uuid.Equals(id) && RequestHelper.IsFeatureEnabled()) {
+                await RequestHelper.SetFeatureEnabled(false);
+            }
+        }
+    }
+}

--- a/src/Microsoft.IIS.Administration.WebServer.RequestMonitor/Controllers/RmRequestsController.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.RequestMonitor/Controllers/RmRequestsController.cs
@@ -13,7 +13,7 @@ namespace Microsoft.IIS.Administration.WebServer.RequestMonitor {
     using Core;
     using Sites;
 
-    [RequireGlobalModule("RequestMonitorModule", "Request Monitor")]
+    [RequireGlobalModule(RequestHelper.MODULE, RequestHelper.DISPLAY_NAME)]
     public class RmRequestsController : ApiBaseController {
 
         [HttpGet]

--- a/src/Microsoft.IIS.Administration.WebServer.RequestMonitor/Defines.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.RequestMonitor/Defines.cs
@@ -10,7 +10,11 @@ namespace Microsoft.IIS.Administration.WebServer.RequestMonitor {
         internal const string WP_IDENTIFIER = "wp.id";
 
         private const string ENDPOINT = "http-request-monitor";
+        private const string REQUESTS_ENDPOINT = "requests";
 
+        //
+        // Request Monitoring
+        public const string MonitorName = "Microsoft.WebServer.RequestMonitoring";
         public static readonly string PATH = $"{WebServer.Defines.PATH}/{ENDPOINT}";
         public static readonly ResDef Resource = new ResDef("request_monitor", new Guid("FE279A67-AE11-4679-AA6A-483362E35B2C"), ENDPOINT);
 
@@ -18,8 +22,7 @@ namespace Microsoft.IIS.Administration.WebServer.RequestMonitor {
         // Requests
         public const string RequestsName = "Microsoft.WebServer.RequestMonitoring.Requests";
         public const string RequestName = "Microsoft.WebServer.RequestMonitoring.Request";
-        private const string REQUESTS_ENDPOINT = "requests";
         public static readonly string REQUESTS_PATH = $"{PATH}/{REQUESTS_ENDPOINT}";
-        public static readonly ResDef RequestsResource = new ResDef("request_monitor", new Guid("8EE648E4-7098-4926-BAAC-DF2CAB2E170E"), REQUESTS_ENDPOINT);
+        public static readonly ResDef RequestsResource = new ResDef("requests", new Guid("8EE648E4-7098-4926-BAAC-DF2CAB2E170E"), REQUESTS_ENDPOINT);
     }
 }

--- a/src/Microsoft.IIS.Administration.WebServer.RequestMonitor/RequestId.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.RequestMonitor/RequestId.cs
@@ -2,7 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 
-namespace Microsoft.IIS.Administration.WebServer.WorkerProcesses {
+namespace Microsoft.IIS.Administration.WebServer.RequestMonitor
+{
     using System;
 
     public class RequestId {

--- a/src/Microsoft.IIS.Administration.WebServer.RequestMonitor/RmId.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.RequestMonitor/RmId.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+
+namespace Microsoft.IIS.Administration.WebServer.RequestMonitor
+{
+    using System;
+
+    public class RmId
+    {
+        private const string PURPOSE = "WebServer.RequestMonitoring";
+
+        public string Uuid { get; private set; }
+
+        public RmId()
+        {
+            Uuid = Core.Utils.Uuid.Encode($"", PURPOSE);
+        }
+
+        public RmId(string uuid)
+        {
+            if (string.IsNullOrEmpty(uuid)) {
+                throw new ArgumentNullException(nameof(uuid));
+            }
+
+            Uuid = uuid;
+        }
+    }
+}

--- a/src/Microsoft.IIS.Administration.WebServer.RequestMonitor/Startup.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.RequestMonitor/Startup.cs
@@ -7,11 +7,30 @@ namespace Microsoft.IIS.Administration.WebServer.RequestMonitor {
     using Core;
     using Core.Http;
 
-
     public class Startup : BaseModule {
 
         public override void Start() {
+            ConfigureRequestMonitoring();
             ConfigureRequests();
+        }
+
+        private void ConfigureRequestMonitoring()
+        {
+            //
+            // Controller
+            Environment.Host.RouteBuilder.MapWebApiRoute(Defines.Resource.Guid, $"{Defines.PATH}/{{id?}}", new { controller = "RequestMonitoring" });
+
+            //
+            // Hal
+            var hal = Environment.Hal;
+
+            // Self
+            hal.ProvideLink(Defines.Resource.Guid, "self", r => new { href = $"/{Defines.PATH}/{r.id}" });
+
+            // Webserver
+            hal.ProvideLink(WebServer.Defines.Resource.Guid, Defines.Resource.Name, _ => {
+                return new { href = RequestHelper.GetLocation() };
+            });
         }
 
         private void ConfigureRequests() {
@@ -36,10 +55,8 @@ namespace Microsoft.IIS.Administration.WebServer.RequestMonitor {
                 return new { href = $"/{Defines.REQUESTS_PATH}?{Sites.Defines.IDENTIFIER}={site.id}" };
             });
 
-            // Webserver
-            hal.ProvideLink(WebServer.Defines.Resource.Guid, Defines.RequestsResource.Name, _ => {
-                return new { href = $"/{Defines.REQUESTS_PATH}" };
-            });
+            // Feature
+            hal.ProvideLink(Defines.Resource.Guid, Defines.RequestsResource.Name, _ => new { href = $"/{Defines.REQUESTS_PATH}" });
         }
     }
 }

--- a/test/Microsoft.IIS.Administration.Tests/IISOptionalFeatures.cs
+++ b/test/Microsoft.IIS.Administration.Tests/IISOptionalFeatures.cs
@@ -24,7 +24,6 @@ namespace Microsoft.IIS.Administration.Tests
         //[InlineData("/api/webserver/http-request-tracing")]
         //[InlineData("/api/webserver/authentication/basic-authentication")]
         //[InlineData("/api/webserver/authentication/digest-authentication")]
-        //[InlineData("/api/webserver/authentication/windows-authentication")]
         //[InlineData("/api/webserver/ip-restrictions")]
         //[InlineData("/api/webserver/logging")]
         //[InlineData("/api/webserver/http-request-tracing")]


### PR DESCRIPTION
Added the ability to uninstall and install the request monitoring feature of IIS. In order to do this there was a **breaking change** with the request monitoring API. The request monitoring endpoint now has a feature associated like the other features of IIS.

Removed the ability to install and uninstall Windows Authentication and URL Authorization. The IIS Administration service depends upon these IIS features so being able to uninstall them could cause the service to damage itself.