### PR TITLE
Added PrivilegeUtil to manipulate ACLs

### DIFF
--- a/scripts/setup/acl-util.ps1
+++ b/scripts/setup/acl-util.ps1
@@ -1,0 +1,220 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+
+Param (
+    [parameter(Mandatory=$true , Position=0)]
+    [ValidateSet("Enable-AclUtil")]
+    [string]
+    $Command
+)
+
+$cs = '
+    namespace Microsoft.IIS.Administration.Setup
+    {
+        using System;
+        using System.ComponentModel;
+        using System.Runtime.InteropServices;
+
+        public class AclUtil
+        {
+            public const string TAKE_OWNERSHIP_PRIVILEGE = "SeTakeOwnershipPrivilege";
+            public const string RESTORE_PRIVILEGE = "SeRestorePrivilege";
+
+            internal const int SE_PRIVILEGE_DISABLED = 0x00000000;
+            internal const int SE_PRIVILEGE_ENABLED = 0x00000002;
+            internal const int TOKEN_QUERY = 0x00000008;
+            internal const int TOKEN_ADJUST_PRIVILEGES = 0x00000020;
+
+            private const string ADVAPI = "advapi32.dll";
+            private const string KERNEL32 = "kernel32.dll";
+
+            [DllImport(ADVAPI, SetLastError = true)]
+            private static extern bool AdjustTokenPrivileges(
+                IntPtr hTokenHandle,
+                bool fDisableAllPrivileges,
+                ref TokPriv1Luid pNewState,
+                int nBufferLength,
+                IntPtr pPreviousState,
+                IntPtr pnReturnLength);
+
+            [DllImport(KERNEL32, SetLastError = true)]
+            private static extern bool CloseHandle(IntPtr hObject);
+
+            [DllImport(KERNEL32)]
+            private static extern IntPtr GetCurrentProcess();
+
+            [DllImport(ADVAPI, SetLastError = true)]
+            private static extern bool GetTokenInformation(
+                IntPtr TokenHandle,
+                TOKEN_INFORMATION_CLASS TokenInformationClass,
+                IntPtr TokenInformation,
+                uint TokenInformationLength,
+                out uint ReturnLength);
+
+            [DllImport(ADVAPI, SetLastError = true, CharSet = CharSet.Unicode)]
+            private static extern bool LookupPrivilegeValueW(
+                string host,
+                string name,
+                ref long pluid);
+
+            [DllImport(ADVAPI, ExactSpelling = true, SetLastError = true)]
+            private static extern bool OpenProcessToken(
+                IntPtr hProcess,
+                int TokenAccess,
+                ref IntPtr phAccessToken);
+
+            [StructLayout(LayoutKind.Sequential, Pack = 1)]
+            private struct TokPriv1Luid
+            {
+                public int Count;
+                public long Luid;
+                public int Attr;
+            }
+
+            [StructLayout(LayoutKind.Sequential)]
+            private class TOKEN_PRIVILEGES
+            {
+                public UInt32 PrivilegeCount;
+                public LUID_AND_ATTRIBUTES[] Privileges;
+            }
+
+            [StructLayout(LayoutKind.Sequential, Pack = 4)]
+            private class LUID_AND_ATTRIBUTES
+            {
+                public long Luid;
+                public UInt32 Attributes;
+            }
+
+            private enum TOKEN_INFORMATION_CLASS
+            {
+                TokenUser = 1,
+                TokenGroups,
+                TokenPrivileges
+            }
+
+            public static void SetPrivilege(string privilege, bool enabled)
+            {
+                IntPtr hAccessToken = IntPtr.Zero;
+                int attribute = enabled ? SE_PRIVILEGE_ENABLED : SE_PRIVILEGE_DISABLED;
+
+                try {
+                    IntPtr hProcess = GetCurrentProcess();
+
+                    if (!OpenProcessToken(hProcess, TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, ref hAccessToken)) {
+                        throw new Win32Exception(Marshal.GetLastWin32Error());
+                    }
+
+                    TokPriv1Luid tp = new TokPriv1Luid();
+                    tp.Count = 1;
+                    tp.Luid = 0;
+                    tp.Attr = attribute;
+
+                    if (!LookupPrivilegeValueW(null, privilege, ref tp.Luid)) {
+                        throw new Win32Exception(Marshal.GetLastWin32Error());
+                    }
+
+                    if (!AdjustTokenPrivileges(hAccessToken, false, ref tp, 0, IntPtr.Zero, IntPtr.Zero)) {
+                        throw new Win32Exception(Marshal.GetLastWin32Error());
+                    }
+                }
+                finally {
+                    if (hAccessToken != IntPtr.Zero) {
+                        CloseHandle(hAccessToken);
+                        hAccessToken = IntPtr.Zero;
+                    }
+                }
+            }
+
+            public static bool HasPrivilege(string privilege)
+            {
+                IntPtr hAccessToken = IntPtr.Zero;
+                IntPtr pTokenInfo = IntPtr.Zero;
+
+                try {
+                    long luid = 0;
+
+                    if (!LookupPrivilegeValueW(null, privilege, ref luid)) {
+                        throw new Win32Exception(Marshal.GetLastWin32Error());
+                    }
+
+                    IntPtr hProcess = GetCurrentProcess();
+
+                    if (!OpenProcessToken(hProcess, TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, ref hAccessToken)) {
+                        throw new Win32Exception(Marshal.GetLastWin32Error());
+                    }
+
+                    //
+                    // Query information size
+                    uint cb;
+                    if (!GetTokenInformation(hAccessToken, TOKEN_INFORMATION_CLASS.TokenPrivileges, pTokenInfo, 0, out cb)) {
+                        pTokenInfo = Marshal.AllocHGlobal((int)cb);
+
+                        if (!GetTokenInformation(hAccessToken, TOKEN_INFORMATION_CLASS.TokenPrivileges, pTokenInfo, cb, out cb)) {
+                            throw new Win32Exception(Marshal.GetLastWin32Error());
+                        }
+                    }
+
+                    TOKEN_PRIVILEGES privileges = MarshalTokenPrivileges(pTokenInfo);
+
+                    foreach (LUID_AND_ATTRIBUTES priv in privileges.Privileges) {
+                        if (priv.Luid == luid) {
+                            return (priv.Attributes & SE_PRIVILEGE_ENABLED) > 0;
+                        }
+                    }
+
+                    return false;
+                }
+                finally {
+                    if (hAccessToken != IntPtr.Zero) {
+                        CloseHandle(hAccessToken);
+                        hAccessToken = IntPtr.Zero;
+                    }
+
+                    if (pTokenInfo != IntPtr.Zero) {
+                        Marshal.FreeHGlobal(pTokenInfo);
+                        pTokenInfo = IntPtr.Zero;
+                    }
+                }
+            }
+
+
+            private static TOKEN_PRIVILEGES MarshalTokenPrivileges(IntPtr buffer)
+            {
+                LUID_AND_ATTRIBUTES[] privs = new LUID_AND_ATTRIBUTES[(uint)Marshal.ReadInt32(buffer)];
+
+                for (int i = 0; i < privs.Length; i++) {
+                    privs[i] = new LUID_AND_ATTRIBUTES();
+                    Marshal.PtrToStructure(new IntPtr(buffer.ToInt64() + sizeof(uint) + Marshal.SizeOf(typeof(LUID_AND_ATTRIBUTES)) * i), privs[i]);
+                }
+
+                TOKEN_PRIVILEGES privileges = new TOKEN_PRIVILEGES();
+                privileges.PrivilegeCount = (uint)privs.Length;
+                privileges.Privileges = privs;
+
+                return privileges;
+            }
+        }
+    }
+'
+
+function InitializeInterop() {
+    try {
+        [Microsoft.IIS.Administration.Setup.AclUtil] | Out-Null
+    }
+    catch {
+        Add-Type $cs
+    }
+}
+
+switch ($Command)
+{
+    "Enable-AclUtil"
+    {
+        InitializeInterop
+    }
+    default
+    {
+        throw "Unknown command"
+    }
+}

--- a/scripts/setup/files.ps1
+++ b/scripts/setup/files.ps1
@@ -1,0 +1,176 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+
+Param(
+    [parameter(Mandatory=$true , Position=0)]
+    [ValidateSet("Remove-ItemForced",
+                 "Copy-FileForced",
+                 "Write-FileForced")]
+    [string]
+    $Command,
+    
+    [parameter()]
+    [string]
+    $Path,
+    
+    [parameter()]
+    [string]
+    $Source,
+    
+    [parameter()]
+    [string]
+    $Destination,
+    
+    [parameter()]
+    [string]
+    $Content
+)
+
+# Removes an item, acquiring access if necessary. Forces recursive delete.
+# Path: The path of the target directory/file.
+function Remove-ItemForced($_path) {
+    
+    if ([System.String]::IsNullOrEmpty($_path)) {
+        throw "Path required"
+    }
+
+    if (-not($(Test-Path $_path))) {
+        return
+    }
+
+    $originalAcl = Get-Acl $_path
+
+    .\security.ps1 Add-SelfRights -Path $_path -Recurse
+
+    try {
+        Remove-Item -Recurse -Force $_path -ErrorAction Stop
+    }
+    catch {
+        .\security.ps1 Set-AclForced -Path $_path -Acl $originalAcl -Recurse
+        throw
+    }
+}
+
+# Copys a file from the source to the destination, acquiring access if necessary. Does not work with directories
+# Source: The source file
+# Destination: The location for the file. If a file exists, the file will be overwritten.
+function Copy-FileForced($_source, $_destination) {
+    
+    if ([System.String]::IsNullOrEmpty($_source)) {
+        throw "Source required"
+    }
+    
+    if ([System.String]::IsNullOrEmpty($_destination)) {
+        throw "Destination required"
+    }
+
+    if (-not($(Test-Path $_source))) {
+        return
+    }
+
+    $source = Get-Item $_source
+
+    if (-not($source -is [System.IO.FileInfo])) {
+        throw "Source must be a file"
+    }
+
+    if ($(Test-Path $_destination)) {
+        Remove-ItemForced($_destination)
+    }
+
+    $parentPath = [System.IO.Path]::GetDirectoryName($_destination)
+    $originalACl = Get-Acl $parentPath
+
+    $newAcl = Get-Acl $parentPath
+    .\security.ps1 Add-SelfRights -Path $parentPath
+
+    try {
+        Copy-Item $_source $_destination -Recurse -Force
+    }
+    finally {
+        .\security.ps1 Set-AclForced -Path $parentPath -Acl $originalACl
+    }
+}
+
+# Writes the content for the file at the specified path
+# Path: The location of the file
+# Content: A string value to write to the file
+function Write-FileForced($_path, $_content) {
+
+    if ([System.String]::IsNullOrEmpty($_path)) {
+        throw "Path required"
+    }
+
+    if (-not($(Test-Path $_path))) {
+        New-FileForced $_path
+    }
+
+    $originalAcl = Get-Acl $_path
+    .\security.ps1 Add-SelfRights -Path $_path
+
+    try {
+        [System.IO.File]::WriteAllText($_path, $_content)
+    }
+    finally {
+        .\security.ps1 Set-AclForced -Path $_path -Acl $originalAcl
+    }
+}
+
+function New-FileForced($_path) {
+
+    if ([System.String]::IsNullOrEmpty($_path)) {
+        throw "Path required"
+    }
+
+    if ($(Test-Path $_path)) {
+        throw "File exists: $_path"
+    }
+
+    $parentPath = [System.IO.Path]::GetDirectoryName($_path)
+    $originalACl = Get-Acl -Path $parentPath
+
+    $newAcl = Get-Acl $parentPath
+    Add-CreateFileEntry $newAcl ([System.Security.Principal.WindowsIdentity]::GetCurrent().User)
+    .\security.ps1 Set-AclForced -Path $parentPath -Acl $newAcl
+
+    try {
+        [System.IO.File]::Create($_path).Dispose()
+    }
+    finally {
+        .\security.ps1 Set-AclForced -Path $parentPath -Acl $originalACl
+    }
+}
+
+function Add-CreateFileEntry($_acl, $_identity) {
+    $create = New-Object System.Security.AccessControl.FileSystemAccessRule(
+						$_identity, 
+						[System.Security.AccessControl.FileSystemRights]"Write,Read,Delete,CreateFiles,CreateDirectories",
+					    [System.Security.AccessControl.InheritanceFlags]::None, 
+						[System.Security.AccessControl.PropagationFlags]::None,
+						[System.Security.AccessControl.AccessControlType]::Allow)
+
+    
+    $_acl.AddAccessRule($create)
+    return $acl
+}
+
+switch($Command)
+{
+    "Remove-ItemForced"
+    {
+        Remove-ItemForced $Path
+    }
+    "Copy-FileForced"
+    {
+        Copy-FileForced $Source $Destination
+    }
+    "Write-FileForced"
+    {
+        Write-FileForced $Path $Content
+    }
+    default
+    {
+        throw "Unknown command"
+    }
+}

--- a/scripts/setup/globals.ps1
+++ b/scripts/setup/globals.ps1
@@ -8,6 +8,8 @@ Param (
                  "DEFAULT_ADMIN_ROOT_NAME",
                  "DEFAULT_INSTALL_PATH",
                  "IIS_HWC_APP_ID",
+                 "INSTALL_METHOD_KEY",
+                 "INSTALL_METHOD_VALUE",
                  "DEFAULT_SERVICE_NAME",
                  "SERVICE_DESCRIPTION",
                  "CERT_NAME",
@@ -16,6 +18,8 @@ Param (
     [string]
     $Command
 )
+
+$INSTALL_METHOD_KEY = "IIS_ADMIN_INSTALL_METHOD"
 
 switch ($Command)
 {
@@ -36,6 +40,20 @@ switch ($Command)
     "IIS_HWC_APP_ID"
     {
         return "{4dc3e181-e14b-4a21-b022-59fc669b0914}"
+    }
+    # Key for retrieving the installation strategy used
+    "INSTALL_METHOD_KEY"
+    {
+        return $INSTALL_METHOD_KEY
+    }
+    # Value of installation strategy
+    "INSTALL_METHOD_VALUE"
+    {
+        $installMethod = Get-Variable -Name $INSTALL_METHOD_KEY -ErrorAction SilentlyContinue
+        if ($installMethod -ne $null) {
+            $installMethod = $installMethod.Value
+        }
+        return $installMethod
     }
     # Application service name
     "DEFAULT_SERVICE_NAME"

--- a/scripts/setup/install.ps1
+++ b/scripts/setup/install.ps1
@@ -326,8 +326,7 @@ function rollback() {
 
         try {
             Write-Host "Rolling back logs folder creation"
-            .\security.ps1 Add-SelfRights -Path $logsPath
-            Remove-Item $logsPath -Force -Recurse
+            .\files.ps1 Remove-ItemForced -Path $logsPath
         }
         catch {
             write-warning "Could not delete logs folder $logsPath."
@@ -341,8 +340,7 @@ function rollback() {
 
         try {
             Write-Host "Rolling back installation folder creation"
-            .\security.ps1 Add-SelfRights -Path $adminRoot
-            Remove-Item $adminRoot -Force -Recurse
+            .\files.ps1 Remove-ItemForced -Path $adminRoot
         }
         catch {
             write-warning "Could not delete installation folder $adminRoot."

--- a/scripts/setup/migrate.ps1
+++ b/scripts/setup/migrate.ps1
@@ -123,10 +123,8 @@ function Migrate {
     $filtered = .\modules.ps1 Remove-DeprecatedModules -Modules $joined
     $oldModules = @{modules = $filtered}
 
-    .\security.ps1 Add-SelfRights -Path $Destination
-
     foreach ($fileName in $userFiles.keys) {
-        Copy-Item -Force -Recurse $(Join-Path $Source $userFiles[$fileName]) $(Join-Path $Destination $userFiles[$fileName]) -ErrorAction SilentlyContinue
+        .\files.ps1 Copy-FileForced -Source $(Join-Path $Source $userFiles[$fileName]) -Destination $(Join-Path $Destination $userFiles[$fileName]) -ErrorAction SilentlyContinue
     }
 
     .\modules.ps1 Set-JsonContent -Path $(Join-Path $Destination $userFiles["modules.json"]) -JsonObject $oldModules
@@ -170,7 +168,7 @@ function Migrate {
     
     # Register the Self Host exe as a service
     $svcExePath = Join-Path $destination "host\$platform\x64\Microsoft.IIS.Host.exe"
-    sc.exe create "$($sourceSettings.ServiceName)" binpath= "$svcExePath -appHostConfig:\`"$appHostPath\`" -serviceName:\`"$($sourceSvc.Name)\`"" start= auto | Out-Null
+    sc.exe create "$($sourceSettings.ServiceName)" depend= http binpath= "$svcExePath -appHostConfig:\`"$appHostPath\`" -serviceName:\`"$($sourceSvc.Name)\`"" start= auto | Out-Null
 
     if ($LASTEXITCODE -ne 0) {
         throw "Could not create new service"

--- a/scripts/setup/modules.ps1
+++ b/scripts/setup/modules.ps1
@@ -105,10 +105,9 @@ function Set-JsonContent($_path, $_jsonObject) {
     if ($_jsonObject -eq $null) {
         throw "JsonObject required"
     }
-
-    New-Item -Type File $_path -Force -ErrorAction Stop | Out-Null
     
-    Serialize $_jsonObject | Out-File $_path -ErrorAction Stop
+    $content = Serialize $_jsonObject
+    .\files.ps1 Write-FileForced -Path $_path -Content $content
 }
 
 # Removes a property from an object

--- a/scripts/setup/msi-setup.ps1
+++ b/scripts/setup/msi-setup.ps1
@@ -89,7 +89,7 @@ function Upgrade() {
         }
         catch {
             # Uninstall must not throw
-            Write-Warning -Exception $_.exception -Message $($_.Exception.Message + [Environment]::NewLine + $_.InvocationInfo.PositionMessage)
+            Write-Warning -Message $($_.Exception.Message + [Environment]::NewLine + $_.InvocationInfo.PositionMessage)
         }
     }
     catch {
@@ -99,7 +99,7 @@ function Upgrade() {
             }
             catch {
                 # Uninstall must not throw
-                Write-Warning -Exception $_.exception -Message $($_.Exception.Message + [Environment]::NewLine + $_.InvocationInfo.PositionMessage)
+                Write-Warning -Message $($_.Exception.Message + [Environment]::NewLine + $_.InvocationInfo.PositionMessage)
             }
         }
         throw $_
@@ -112,10 +112,12 @@ function Uninstall() {
     .\uninstall.ps1 -Path $adminRoot -KeepFiles
 }
 
+Require-Script "acl-util"
 Require-Script "cache"
 Require-Script "cert"
 Require-Script "config"
 Require-Script "dependencies"
+Require-Script "files"
 Require-Script "globals"
 Require-Script "migrate"
 Require-Script "modules"
@@ -130,6 +132,7 @@ Require-Script "ver"
 try {
     Push-Location $(Get-ScriptDirectory)
     .\require.ps1 Is-Administrator
+    Set-Variable -Name $(.\globals.ps1 INSTALL_METHOD_KEY) -Value "MSI" -Scope Global
     
     switch($Command)
     {
@@ -151,7 +154,7 @@ try {
                 Uninstall
             }
             catch {
-                Write-Warning -Exception $_.exception -Message $($_.Exception.Message + [Environment]::NewLine + $_.InvocationInfo.PositionMessage)
+                Write-Warning -Message $($_.Exception.Message + [Environment]::NewLine + $_.InvocationInfo.PositionMessage)
             }
         }
         default
@@ -165,6 +168,7 @@ catch {
     exit -1
 }
 finally {
+    Clear-Variable -Name $(.\globals.ps1 INSTALL_METHOD_KEY) -Scope Global
     Pop-Location
 }
 exit 0


### PR DESCRIPTION
Uninstall was throwing errors on Server 2012 and below due to the uninstalling user not having full control over directories/files despite being an administrator. The privileges.ps1 script was added to provide _Microsoft.IIS.Administration.Setup.PrivilegeUtil_ which can enable the necessary privilege to set proper ACLs during installation. Any privileges added during installation are immediately reverted after being used.