### PR TITLE
Succeed installation with 32 bit .NET Core

### DIFF
--- a/scripts/setup/require.ps1
+++ b/scripts/setup/require.ps1
@@ -30,8 +30,12 @@ function Dotnet {
     elseif ($dotnet -ne $null) {
         $source = $dotnet.Definition
     }
+    
+    $dotnetSuffix = "dotnet\dotnet.exe"
+    $isInProgramFiles = $source -eq $(Join-Path $env:ProgramFiles $dotnetSuffix)
+    $isInProgramFilesx86 = $source -eq $(Join-Path ${env:ProgramFiles(x86)} $dotnetSuffix)
 
-    if(-not($source -eq $(Join-Path $env:ProgramFiles "dotnet\dotnet.exe"))) {
+    if(-not($isInProgramFiles) -and -not($isInProgramFilesx86)) {
         Write-Warning ".NET Core Shared Framework not installed"
         Write-Warning "Download the .NET Core Runtime (LTS) 'https://www.microsoft.com/net/download/core#/runtime'"
         throw ".NET Core required to continue"

--- a/test/Microsoft.IIS.Administration.Tests/Sites.cs
+++ b/test/Microsoft.IIS.Administration.Tests/Sites.cs
@@ -71,7 +71,7 @@ namespace Microsoft.IIS.Administration.Tests
 
                 site["server_auto_start"] = !site.Value<bool>("server_auto_start");
                 site["physical_path"] = Configuration.TEST_ROOT_PATH;
-                site["enabled_protocols"] = "test_protocol";
+                site["enabled_protocols"] = site.Value<string>("enabled_protocols").Equals("http", StringComparison.OrdinalIgnoreCase) ? "https" : "http";
 
                 // If site status is unknown then we don't know if it will be started or stopped when it becomes available
                 // Utilizing the defaults we assume it will go from unkown to started


### PR DESCRIPTION
Updated setup script to recognize dotnet.exe if it is installed in Program Files (x86)