### PR TITLE
Web site key creation fix

### DIFF
--- a/src/Microsoft.IIS.Administration.WebServer.Sites/SiteHelper.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Sites/SiteHelper.cs
@@ -55,11 +55,11 @@ namespace Microsoft.IIS.Administration.WebServer.Sites
             // Initialize new site settings
             SetToDefaults(site, sm.SiteDefaults);
 
-            // Set site settings to those provided
-            SetSite(site, model, fileProvider);
-
             // Initialize site Id by obtaining the first available
             site.Id = FirstAvailableId();
+
+            // Set site settings to those provided
+            SetSite(site, model, fileProvider);
 
             return site;
         }

--- a/test/Microsoft.IIS.Administration.Tests/Sites.cs
+++ b/test/Microsoft.IIS.Administration.Tests/Sites.cs
@@ -383,6 +383,36 @@ namespace Microsoft.IIS.Administration.Tests
             }
         }
 
+        [Theory]
+        [InlineData(99722)]
+        public void CreateWithKey(int key)
+        {
+            using (HttpClient client = ApiHttpClient.Create()) {
+
+                EnsureNoSite(client, TEST_SITE_NAME);
+
+                var siteData = new {
+                    name = TEST_SITE_NAME,
+                    physical_path = TEST_SITE_PATH,
+                    key = key,
+                    bindings = new object[] {
+                        new {
+                            ip_address = "*",
+                            port = TEST_PORT,
+                            protocol = "http"
+                        }
+                    }
+                };
+
+                JObject site = client.Post(SITE_URL, siteData);
+                Assert.NotNull(site);
+
+                Assert.Equal(key, site.Value<int>("key"));
+
+                Assert.True(client.Delete(Utils.Self(site)));
+            }
+        }
+
         private bool HasExactProperties(JObject obj, IEnumerable<string> names) {
             if (obj.Properties().Count() != names.Count()) {
                 return false;


### PR DESCRIPTION
Fixed issue causing a site's key property to take the next available value on creation.

In response to #108 