### PR TITLE
Renew IIS Administration Certificate on Upgrade if necessary

### DIFF
--- a/scripts/setup/config.ps1
+++ b/scripts/setup/config.ps1
@@ -189,7 +189,7 @@ function Write-Config($obj, $_path) {
 }
 
 # Gets the port that the IIS Administration API is configured to listen on
-# Source: The installation path, Ex: C:\Program Files\IIS Administration\2.0.0
+# Path: The installation path, Ex: C:\Program Files\IIS Administration\2.0.0
  function Get-ConfigPort($_path) {
     if ([string]::IsNullOrEmpty($_path)) {
         throw "Path required."
@@ -221,13 +221,19 @@ function Write-Config($obj, $_path) {
         $sPort = $urls.Substring($start, $urls.Length - $start)
     }
 
-    if ($sPort -ne $null -and -not([int]::TryParse($sPort, [ref]$port))) {
+    if ($sPort -ne $null) {
+        try {
+            $port = [int]::parse($sPort)
+        }
+        catch {
             throw "Misconfigured 'urls' in appsettings: $($appsettings.urls)."
+        }
     }
 
     $port
  }
 
+# Legacy (Pre 2.0.0)
 # Gets the port that the IIS Administration site is configured to listen on in the applicationHost.config file.
 # AppHostPath: The location of the applicationHost.config file.
 function Get-AppHostPort($_appHostPath) {

--- a/scripts/setup/migrate.ps1
+++ b/scripts/setup/migrate.ps1
@@ -125,6 +125,13 @@ function Migrate {
 
     $userFiles = .\config.ps1 Get-UserFileMap
     
+    # Copy over Ssl bindings, in this case the source and destination are reversed
+    $sourcePort = .\config.ps1 Get-ConfigPort -Path $Destination
+    $destinationPort = .\config.ps1 Get-ConfigPort -Path $Source
+    if ($sourcePort -ne $destinationPort) {
+        .\net.ps1 CopySslBindingInfo -SourcePort $sourcePort -DestinationPort $destinationPort
+    }
+
     .\modules.ps1 Migrate-Modules -Source $Source -Destination $Destination
     .\config.ps1 Migrate-AppSettings -Source $Source -Destination $Destination
     .\files.ps1 Copy-FileForced -Source $(Join-Path $Source $userFiles["api-keys.json"]) -Destination $(Join-Path $Destination $userFiles["api-keys.json"]) -ErrorAction SilentlyContinue


### PR DESCRIPTION
The IIS Administration Certificate Server Certificate will now be renewed on installation if it will expire in less than 90 days (~3 months)