### PR TITLE
Code improvements in ModulesId.cs and CorsExtensions.cs

### DIFF
--- a/src/Microsoft.IIS.Administration.WebServer.Authorization/AuthorizationId.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Authorization/AuthorizationId.cs
@@ -55,12 +55,12 @@ namespace Microsoft.IIS.Administration.WebServer.Authorization
         {
 
             if (!string.IsNullOrEmpty(path) && siteId == null) {
-                throw new ArgumentNullException("siteId");
+                throw new ArgumentNullException(nameof(siteId));
             }
 
             this.Path = path;
             this.SiteId = siteId;
-            this.IsLocal = IsLocal;
+            this.IsLocal = isLocal;
 
             string encodableSiteId = this.SiteId == null ? "" : this.SiteId.Value.ToString();
             string encodableIsLocal = (this.IsLocal ? 1 : 0).ToString();

--- a/src/Microsoft.IIS.Administration.WebServer.Handlers/HandlersId.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Handlers/HandlersId.cs
@@ -55,12 +55,12 @@ namespace Microsoft.IIS.Administration.WebServer.Handlers
         {
 
             if (!string.IsNullOrEmpty(path) && siteId == null) {
-                throw new ArgumentNullException("siteId");
+                throw new ArgumentNullException(nameof(siteId));
             }
 
             this.Path = path;
             this.SiteId = siteId;
-            this.IsLocal = IsLocal;
+            this.IsLocal = isLocal;
 
             string encodableSiteId = this.SiteId == null ? "" : this.SiteId.Value.ToString();
             string encodableIsLocal = (this.IsLocal ? 1 : 0).ToString();

--- a/src/Microsoft.IIS.Administration.WebServer.HttpResponseHeaders/HttpResponseHeadersId.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.HttpResponseHeaders/HttpResponseHeadersId.cs
@@ -55,12 +55,12 @@ namespace Microsoft.IIS.Administration.WebServer.HttpResponseHeaders
         {
 
             if (!string.IsNullOrEmpty(path) && siteId == null) {
-                throw new ArgumentNullException("siteId");
+                throw new ArgumentNullException(nameof(siteId));
             }
 
             this.Path = path;
             this.SiteId = siteId;
-            this.IsLocal = IsLocal;
+            this.IsLocal = isLocal;
 
             string encodableSiteId = this.SiteId == null ? "" : this.SiteId.Value.ToString();
             string encodableIsLocal = (this.IsLocal ? 1 : 0).ToString();

--- a/src/Microsoft.IIS.Administration.WebServer.Logging/LoggingId.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Logging/LoggingId.cs
@@ -55,12 +55,12 @@ namespace Microsoft.IIS.Administration.WebServer.Logging
         {
 
             if (!string.IsNullOrEmpty(path) && siteId == null) {
-                throw new ArgumentNullException("siteId");
+                throw new ArgumentNullException(nameof(siteId));
             }
 
             this.Path = path;
             this.SiteId = siteId;
-            this.IsLocal = IsLocal;
+            this.IsLocal = isLocal;
 
             string encodableSiteId = this.SiteId == null ? "" : this.SiteId.Value.ToString();
             string encodableIsLocal = (this.IsLocal ? 1 : 0).ToString();

--- a/src/Microsoft.IIS.Administration.WebServer.Modules/ModulesId.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Modules/ModulesId.cs
@@ -60,7 +60,7 @@ namespace Microsoft.IIS.Administration.WebServer.Modules
 
             this.Path = path;
             this.SiteId = siteId;
-            this.IsLocal = IsLocal;
+            this.IsLocal = isLocal;
 
             string encodableSiteId = this.SiteId == null ? "" : this.SiteId.Value.ToString();
             string encodableIsLocal = (this.IsLocal ? 1 : 0).ToString();

--- a/src/Microsoft.IIS.Administration.WebServer.StaticContent/StaticContentId.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.StaticContent/StaticContentId.cs
@@ -55,12 +55,12 @@ namespace Microsoft.IIS.Administration.WebServer.StaticContent
         {
 
             if (!string.IsNullOrEmpty(path) && siteId == null) {
-                throw new ArgumentNullException("siteId");
+                throw new ArgumentNullException(nameof(siteId));
             }
 
             this.Path = path;
             this.SiteId = siteId;
-            this.IsLocal = IsLocal;
+            this.IsLocal = isLocal;
 
             string encodableSiteId = this.SiteId == null ? "" : this.SiteId.Value.ToString();
             string encodableIsLocal = (this.IsLocal ? 1 : 0).ToString();

--- a/src/Microsoft.IIS.Administration/Cors/CorsExtensions.cs
+++ b/src/Microsoft.IIS.Administration/Cors/CorsExtensions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.IIS.Administration.Cors
         {
             //
             // Allow CORs for rootPath only
-            if (!string.IsNullOrEmpty(rootPath) || rootPath != "/") {
+            if (!string.IsNullOrEmpty(rootPath) && rootPath != "/") {
                 builder.Use(async (context, next) => {
 
                     bool isCorsPreflight = context.Request.Method.Equals("OPTIONS", StringComparison.OrdinalIgnoreCase) &&

--- a/src/Microsoft.IIS.Administration/Utils/TimeSpanExtentions.cs
+++ b/src/Microsoft.IIS.Administration/Utils/TimeSpanExtentions.cs
@@ -45,7 +45,7 @@ namespace Microsoft.IIS.Administration.Utils {
 
             // Seconds
             if (Math.Abs(ts.TotalMinutes) < 1) {
-                sb.AppendFormat("a few moments ", minutes, minutes > 1 ? "s" : "");
+                sb.AppendFormat("a few moments ");
             }
 
 


### PR DESCRIPTION
Closes #132
Replace the || operator with the && one.
Remove unused arguments.