### PR TITLE
Fixed powershell method invocation not present in all versions of PowerShell.

### DIFF
--- a/scripts/setup/cert.ps1
+++ b/scripts/setup/cert.ps1
@@ -244,8 +244,8 @@ function Create-SelfSignedCertificate($_subject, $_friendlyName, $_alternativeNa
     } while ($CACertificate -eq $null -and $(Get-Date) -lt $end)
 
     if ($CACertificate.Length -ne $null) {
-        $dates = $CACertificate | %{[System.DateTime]::Parse($_.GetEffectiveDateString())} | Sort-Object
-        $CACertificate = $CACertificate | where {[System.DateTime]::Parse($_.GetEffectiveDateString()) -eq $dates[$dates.length - 1]}
+        $dates = $CACertificate | %{$_.NotBefore} | Sort-Object
+        $CACertificate = $CACertificate | where {$_.NotBefore -eq $dates[$dates.length - 1]}
     }
 
     return $CACertificate 
@@ -297,8 +297,8 @@ function Get-LatestIISAdminCert {
     $certs = Get-IISAdminCerts
 
     if ($certs -ne $null -and $certs.length -ne $null) {
-        $expirationDates = $certs | %{[System.DateTime]::Parse($_.GetExpirationDateString())} | Sort-Object
-        $cert = $certs | where {[System.DateTime]::Parse($_.GetExpirationDateString()) -eq $expirationDates[$expirationDates.length - 1]}
+        $expirationDates = $certs | %{$_.NotAfter} | Sort-Object
+        $cert = $certs | where {$_.NotAfter -eq $expirationDates[$expirationDates.length - 1]}
     }
     else {
         $cert = $certs

--- a/scripts/setup/install.ps1
+++ b/scripts/setup/install.ps1
@@ -374,7 +374,7 @@ function Install
         if ($cert -ne $null) {
             #
             # Check if existing cert has sufficient lifespan left (3+ months)
-            $expirationDate = [System.DateTime]::Parse($cert.GetExpirationDateString())
+            $expirationDate = $cert.NotAfter
             $remainingLifetime = $expirationDate - [System.DateTime]::Now
 
             if ($remainingLifetime.TotalDays -lt $(.\globals.ps1 CERT_EXPIRATION_WINDOW)) {

--- a/scripts/setup/migrate.ps1
+++ b/scripts/setup/migrate.ps1
@@ -194,7 +194,7 @@ function Migrate {
     # Remove expired IIS Administration certificates
     $certs = .\cert.ps1 Get-IISAdminCertificates
     foreach ($cert in $certs) {
-        if ((([System.DateTime]::Parse($cert.GetExpirationDateString()) - [System.DateTime]::Now).TotalDays -lt 0) -and $cert.Thumbprint.ToLower() -ne $sslBindingInfo.CertificateHash.ToLower()) {
+        if ((($cert.NotAfter - [System.DateTime]::Now).TotalDays -lt 0) -and $cert.Thumbprint.ToLower() -ne $sslBindingInfo.CertificateHash.ToLower()) {
             Write-Verbose "Removing old IIS Administration Certificate"
             .\cert.ps1 Delete -Thumbprint $cert.Thumbprint
         }


### PR DESCRIPTION
NotAfter and NotBefore are the appropriate methods to call rather than parsing a datetime string.

Prompted by #137