### PR TITLE
Added system level counters for cpu and memory usage.

### DIFF
--- a/src/Microsoft.IIS.Administration.WebServer.Monitoring/AppPools/AppPoolHelper.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Monitoring/AppPools/AppPoolHelper.cs
@@ -42,9 +42,10 @@ namespace Microsoft.IIS.Administration.WebServer.Monitoring
             if (fields.Exists("memory")) {
                 obj.memory = new {
                     handles = snapshot.HandleCount,
-                    private_working_set = snapshot.PrivateWorkingSet,
                     private_bytes = snapshot.PrivateBytes,
-                    available = snapshot.AvailableBytes
+                    private_working_set = snapshot.PrivateWorkingSet,
+                    system_in_use = snapshot.SystemMemoryInUse,
+                    installed = snapshot.TotalInstalledMemory
                 };
             }
 

--- a/src/Microsoft.IIS.Administration.WebServer.Monitoring/AppPools/AppPoolSnapshot.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Monitoring/AppPools/AppPoolSnapshot.cs
@@ -22,7 +22,11 @@ namespace Microsoft.IIS.Administration.WebServer.Monitoring
 
         public long PrivateWorkingSet { get; set; }
 
-        public long AvailableBytes { get; set; }
+        public long AvailableMemory { get; set; }
+
+        public long SystemMemoryInUse { get; set; }
+
+        public long TotalInstalledMemory { get; set; }
 
         public long WorkingSet { get; set; }
 

--- a/src/Microsoft.IIS.Administration.WebServer.Monitoring/AppPools/IAppPoolSnapshot.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Monitoring/AppPools/IAppPoolSnapshot.cs
@@ -22,7 +22,11 @@ namespace Microsoft.IIS.Administration.WebServer.Monitoring
 
         long PrivateWorkingSet { get; set; }
 
-        long AvailableBytes { get; set; }
+        long AvailableMemory { get; set; }
+
+        long SystemMemoryInUse { get; set; }
+
+        long TotalInstalledMemory { get; set; }
 
         long WorkingSet { get; set; }
 

--- a/src/Microsoft.IIS.Administration.WebServer.Monitoring/Core/Interop.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Monitoring/Core/Interop.cs
@@ -25,6 +25,7 @@ namespace Microsoft.IIS.Administration.Monitoring
             }
         }
     }
+
     public class PdhLogHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
         public PdhLogHandle() : base(true)
@@ -100,7 +101,7 @@ namespace Microsoft.IIS.Administration.Monitoring
         PDH_NOEXPANDINSTANCES  = 2
     }
 
-    public class Pdh
+    class Pdh
     {
         private const string PerformanceCounterLib = "pdh.dll";
 

--- a/src/Microsoft.IIS.Administration.WebServer.Monitoring/CounterNames.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Monitoring/CounterNames.cs
@@ -154,4 +154,14 @@ namespace Microsoft.IIS.Administration.WebServer.Monitoring
             UriCacheMisses
         };
     }
+
+    static class ProcessorCounterNames
+    {
+        public const string Category = "Processor";
+        public const string IdleTime = "% Idle Time";
+
+        public static readonly string[] CounterNames = new string[] {
+            IdleTime
+        };
+    }
 }

--- a/src/Microsoft.IIS.Administration.WebServer.Monitoring/Sites/IWebSiteSnapshot.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Monitoring/Sites/IWebSiteSnapshot.cs
@@ -70,7 +70,11 @@ namespace Microsoft.IIS.Administration.WebServer.Monitoring
 
         long PrivateBytes { get; set; }
 
-        long AvailableBytes { get; set; }
+        long AvailableMemory { get; set; }
+
+        long SystemMemoryInUse { get; set; }
+
+        long TotalInstalledMemory { get; set; }
 
         long HandleCount { get; set; }
 

--- a/src/Microsoft.IIS.Administration.WebServer.Monitoring/Sites/SiteHelper.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Monitoring/Sites/SiteHelper.cs
@@ -62,9 +62,10 @@ namespace Microsoft.IIS.Administration.WebServer.Monitoring
             if (fields.Exists("memory")) {
                 obj.memory = new {
                     handles = snapshot.HandleCount,
-                    private_working_set = snapshot.PrivateWorkingSet,
                     private_bytes = snapshot.PrivateBytes,
-                    available = snapshot.AvailableBytes
+                    private_working_set = snapshot.PrivateWorkingSet,
+                    system_in_use = snapshot.SystemMemoryInUse,
+                    installed = snapshot.TotalInstalledMemory
                 };
             }
 

--- a/src/Microsoft.IIS.Administration.WebServer.Monitoring/Sites/WebSiteSnapshot.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Monitoring/Sites/WebSiteSnapshot.cs
@@ -70,7 +70,11 @@ namespace Microsoft.IIS.Administration.WebServer.Monitoring
 
         public long PrivateBytes { get; set; }
 
-        public long AvailableBytes { get; set; }
+        public long AvailableMemory { get; set; }
+
+        public long SystemMemoryInUse { get; set; }
+
+        public long TotalInstalledMemory { get; set; }
 
         public long HandleCount { get; set; }
 

--- a/src/Microsoft.IIS.Administration.WebServer.Monitoring/Util/MemoryData.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Monitoring/Util/MemoryData.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+
+
+namespace Microsoft.IIS.Administration.WebServer.Monitoring
+{
+    class MemoryData
+    {
+        private static MEMORYSTATUSEX _memoryStatus = null;
+
+        public static long TotalInstalledMemory {
+            get {
+                if (_memoryStatus == null) {
+                    _memoryStatus = new MEMORYSTATUSEX();
+                    NativeMethods.GlobalMemoryStatusEx(_memoryStatus);
+                }
+
+                return (long)_memoryStatus.ullTotalPhys;
+            }
+        }
+    }
+}

--- a/src/Microsoft.IIS.Administration.WebServer.Monitoring/Util/ProcessUtil.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Monitoring/Util/ProcessUtil.cs
@@ -179,10 +179,31 @@ namespace Microsoft.IIS.Administration.WebServer.Monitoring
         internal string szExeFile;
     }
 
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    class MEMORYSTATUSEX
+    {
+        public uint dwLength;
+        public uint dwMemoryLoad;
+        public ulong ullTotalPhys;
+        public ulong ullAvailPhys;
+        public ulong ullTotalPageFile;
+        public ulong ullAvailPageFile;
+        public ulong ullTotalVirtual;
+        public ulong ullAvailVirtual;
+        public ulong ullAvailExtendedVirtual;
+        public MEMORYSTATUSEX()
+        {
+            this.dwLength = (uint)Marshal.SizeOf<MEMORYSTATUSEX>();
+        }
+    }
+
     class NativeMethods
     {
         private const string ProcessLib = "kernel32";
         public static readonly IntPtr INVALID_HANDLE_VALUE = new IntPtr(-1);
+
+        [DllImport(ProcessLib, SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern bool GlobalMemoryStatusEx([In, Out] MEMORYSTATUSEX lpBuffer);
 
         [DllImport(ProcessLib, SetLastError = true, CharSet = CharSet.Unicode)]
         public static extern IntPtr CreateToolhelp32Snapshot([In]UInt32 dwFlags, [In]UInt32 th32ProcessID);

--- a/src/Microsoft.IIS.Administration.WebServer.Monitoring/WebServer/IWebServerSnapshot.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Monitoring/WebServer/IWebServerSnapshot.cs
@@ -30,6 +30,8 @@ namespace Microsoft.IIS.Administration.WebServer.Monitoring
 
         long PercentCpuTime { get; }
 
+        long SystemPercentCpuTime { get; set; }
+
         long PrivateWorkingSet { get; set; }
 
         long WorkingSet { get; }
@@ -48,7 +50,11 @@ namespace Microsoft.IIS.Administration.WebServer.Monitoring
 
         long FileCacheMisses { get; set; }
 
-        long AvailableBytes { get; set; }
+        long AvailableMemory { get; set; }
+
+        long SystemMemoryInUse { get; set; }
+
+        long TotalInstalledMemory { get; set; }
 
         long FileCacheMemoryUsage { get; set; }
 

--- a/src/Microsoft.IIS.Administration.WebServer.Monitoring/WebServer/WebServerHelper.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Monitoring/WebServer/WebServerHelper.cs
@@ -54,9 +54,10 @@ namespace Microsoft.IIS.Administration.WebServer.Monitoring
             if (fields.Exists("memory")) {
                 obj.memory = new {
                     handles = snapshot.HandleCount,
-                    private_working_set = snapshot.PrivateWorkingSet,
                     private_bytes = snapshot.PrivateBytes,
-                    available = snapshot.AvailableBytes
+                    private_working_set = snapshot.PrivateWorkingSet,
+                    system_in_use = snapshot.SystemMemoryInUse,
+                    installed = snapshot.TotalInstalledMemory
                 };
             }
 
@@ -64,9 +65,10 @@ namespace Microsoft.IIS.Administration.WebServer.Monitoring
             // cpu
             if (fields.Exists("cpu")) {
                 obj.cpu = new {
-                    percent_usage = snapshot.PercentCpuTime,
                     threads = snapshot.ThreadCount,
-                    processes = snapshot.ProcessCount
+                    processes = snapshot.ProcessCount,
+                    percent_usage = snapshot.PercentCpuTime,
+                    system_percent_usage = snapshot.SystemPercentCpuTime
                 };
             }
 

--- a/src/Microsoft.IIS.Administration.WebServer.Monitoring/WebServer/WebServerSnapshot.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Monitoring/WebServer/WebServerSnapshot.cs
@@ -30,6 +30,8 @@ namespace Microsoft.IIS.Administration.WebServer.Monitoring
 
         public long PercentCpuTime { get; set; }
 
+        public long SystemPercentCpuTime { get; set; }
+
         public long HandleCount { get; set; }
 
         public long PrivateWorkingSet { get; set; }
@@ -48,7 +50,11 @@ namespace Microsoft.IIS.Administration.WebServer.Monitoring
 
         public long FileCacheMisses { get; set; }
 
-        public long AvailableBytes { get; set; }
+        public long AvailableMemory { get; set; }
+
+        public long SystemMemoryInUse { get; set; }
+
+        public long TotalInstalledMemory { get; set; }
 
         public long FileCacheMemoryUsage { get; set; }
 

--- a/test/Microsoft.IIS.Administration.Tests/Monitoring.cs
+++ b/test/Microsoft.IIS.Administration.Tests/Monitoring.cs
@@ -20,7 +20,7 @@ namespace Microsoft.IIS.Administration.Tests
         private static readonly string SitePath = Path.Combine(Configuration.TEST_ROOT_PATH, SiteName);
 
         [Fact]
-        public async Task MonitorWebServer()
+        public async Task WebServer()
         {
             using (HttpClient client = ApiHttpClient.Create()) {
                 Sites.EnsureNoSite(client, SiteName);
@@ -51,11 +51,15 @@ namespace Microsoft.IIS.Administration.Tests
                         Assert.True(snapshot["requests"].Value<long>("per_sec") > 0);
                         Assert.True(snapshot["network"].Value<long>("total_bytes_sent") > 0);
                         Assert.True(snapshot["network"].Value<long>("total_bytes_recv") > 0);
+                        Assert.True(snapshot["network"].Value<long>("total_connection_attempts") > 0);
                         Assert.True(snapshot["requests"].Value<long>("total") > 0);
                         Assert.True(snapshot["memory"].Value<long>("private_working_set") > 0);
-                        Assert.True(snapshot["memory"].Value<long>("available") > 0);
+                        Assert.True(snapshot["memory"].Value<long>("system_in_use") > 0);
+                        Assert.True(snapshot["memory"].Value<long>("installed") > 0);
                         Assert.True(snapshot["cpu"].Value<long>("threads") > 0);
                         Assert.True(snapshot["cpu"].Value<long>("processes") > 0);
+                        Assert.True(snapshot["cpu"].Value<long>("percent_usage") >= 0);
+                        Assert.True(snapshot["cpu"].Value<long>("system_percent_usage") >= 0);
 
                         Assert.True(serverMonitor.ErrorCount == 0);
                     }
@@ -187,9 +191,14 @@ namespace Microsoft.IIS.Administration.Tests
 
                 Assert.True(snapshot["network"].Value<long>("total_bytes_sent") > 0);
                 Assert.True(snapshot["network"].Value<long>("total_bytes_recv") > 0);
+                Assert.True(snapshot["network"].Value<long>("total_connection_attempts") > 0);
                 Assert.True(snapshot["requests"].Value<long>("total") > 0);
                 Assert.True(snapshot["memory"].Value<long>("private_working_set") > 0);
-                Assert.True(snapshot["memory"].Value<long>("available") > 0);
+                Assert.True(snapshot["memory"].Value<long>("system_in_use") > 0);
+                Assert.True(snapshot["memory"].Value<long>("installed") > 0);
+                Assert.True(snapshot["cpu"].Value<long>("threads") > 0);
+                Assert.True(snapshot["cpu"].Value<long>("processes") > 0);
+                Assert.True(snapshot["cpu"].Value<long>("percent_usage") >= 0);
                 Assert.True(snapshot["cpu"].Value<long>("threads") > 0);
                 Assert.True(snapshot["cpu"].Value<long>("processes") > 0);
 
@@ -222,7 +231,7 @@ namespace Microsoft.IIS.Administration.Tests
         }
 
         [Fact]
-        public async Task MonitorWebSite()
+        public async Task WebSite()
         {
             const string name = SiteName + "z";
 
@@ -266,9 +275,11 @@ namespace Microsoft.IIS.Administration.Tests
                         Assert.True(snapshot["requests"].Value<long>("per_sec") > 0);
                         Assert.True(snapshot["network"].Value<long>("total_bytes_sent") > 0);
                         Assert.True(snapshot["network"].Value<long>("total_bytes_recv") > 0);
+                        Assert.True(snapshot["network"].Value<long>("total_connection_attempts") > 0);
                         Assert.True(snapshot["requests"].Value<long>("total") > 0);
                         Assert.True(snapshot["memory"].Value<long>("private_working_set") > 0);
-                        Assert.True(snapshot["memory"].Value<long>("available") > 0);
+                        Assert.True(snapshot["memory"].Value<long>("system_in_use") > 0);
+                        Assert.True(snapshot["memory"].Value<long>("installed") > 0);
                         Assert.True(snapshot["cpu"].Value<long>("threads") > 0);
                         Assert.True(snapshot["cpu"].Value<long>("processes") > 0);
 
@@ -284,7 +295,7 @@ namespace Microsoft.IIS.Administration.Tests
         }
 
         [Fact]
-        public async Task MonitorAppPool()
+        public async Task AppPool()
         {
             using (HttpClient client = ApiHttpClient.Create()) {
                 Sites.EnsureNoSite(client, SiteName);
@@ -304,7 +315,8 @@ namespace Microsoft.IIS.Administration.Tests
 
                         Assert.True(snapshot["requests"].Value<long>("total") > 0);
                         Assert.True(snapshot["memory"].Value<long>("private_working_set") > 0);
-                        Assert.True(snapshot["memory"].Value<long>("available") > 0);
+                        Assert.True(snapshot["memory"].Value<long>("system_in_use") > 0);
+                        Assert.True(snapshot["memory"].Value<long>("installed") > 0);
                         Assert.True(snapshot["cpu"].Value<long>("threads") > 0);
                         Assert.True(snapshot["cpu"].Value<long>("processes") > 0);
 


### PR DESCRIPTION
### Web Server

Added memory.system_in_use and memory.installed, and cpu.system_percent_usage. Removed memory.available.

```
{
    "id": "{id}",
    "network": {
        "bytes_sent_sec": "0",
        "bytes_recv_sec": "0",
        "connection_attempts_sec": "0",
        "total_bytes_sent": "0",
        "total_bytes_recv": "0",
        "total_connection_attempts": "0",
        "current_connections": "0"
    },
    "requests": {
        "active": "0",
        "per_sec": "0",
        "total": "0"
    },
    "memory": {
        "handles": "0",
        "private_bytes": "0",
        "private_working_set": "0",
        "system_in_use": "6114807808",
        "installed": "13102534656"
    },
    "cpu": {
        "threads": "0",
        "processes": "0",
        "percent_usage": "0",
        "system_percent_usage": "4"
    },
    "disk": {
        "io_write_operations_sec": "0",
        "io_read_operations_sec": "0",
        "page_faults_sec": "0"
    },
    "cache": {
        "file_cache_count": "0",
        "file_cache_memory_usage": "0",
        "file_cache_hits": "0",
        "file_cache_misses": "0",
        "total_files_cached": "0",
        "output_cache_count": "0",
        "output_cache_memory_usage": "0",
        "output_cache_hits": "0",
        "output_cache_misses": "0",
        "uri_cache_count": "0",
        "uri_cache_hits": "0",
        "uri_cache_misses": "0",
        "total_uris_cached": "0"
    },
    "_links": {
        "self": {
            "href": "/api/webserver/monitoring/{id}"
        }
    }
}
```


### Web Site

Added memory.system_in_use and memory.installed. Removed memory.available.

```
{
    "id": "{id}",
    "uptime": "10",
    "network": {
        "bytes_sent_sec": "0",
        "bytes_recv_sec": "0",
        "connection_attempts_sec": "0",
        "total_bytes_sent": "110132",
        "total_bytes_recv": "1547",
        "total_connection_attempts": "1",
        "current_connections": "1"
    },
    "requests": {
        "active": "0",
        "per_sec": "0",
        "total": "4"
    },
    "memory": {
        "handles": "353",
        "private_bytes": "8683520",
        "private_working_set": "7667712",
        "system_in_use": "6160146432",
        "installed": "12880236544"
    },
    "cpu": {
        "percent_usage": "0",
        "threads": "26",
        "processes": "1"
    },
    "disk": {
        "io_write_operations_sec": "0",
        "io_read_operations_sec": "0",
        "page_faults_sec": "0"
    },
    "cache": {
        "file_cache_count": "1",
        "file_cache_memory_usage": "699",
        "file_cache_hits": "1",
        "file_cache_misses": "10",
        "total_files_cached": "1",
        "output_cache_count": "0",
        "output_cache_memory_usage": "0",
        "output_cache_hits": "0",
        "output_cache_misses": "5",
        "uri_cache_count": "1",
        "uri_cache_hits": "0",
        "uri_cache_misses": "5",
        "total_uris_cached": "1"
    },
    "website": {
        "name": "Default Web Site",
        "id": "{id}",
        "status": "started",
        "_links": {
            "self": {
                "href": "/api/webserver/websites/{id}"
            }
        }
    },
    "_links": {
        "self": {
            "href": "/api/webserver/websites/monitoring/{id}"
        }
    }
}
```