### PR TITLE
Added support for localized OSes by translating performance counter names.

### DIFF
--- a/src/Microsoft.IIS.Administration.WebServer.Monitoring/AppPools/AppPoolMonitor.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Monitoring/AppPools/AppPoolMonitor.cs
@@ -16,16 +16,22 @@ namespace Microsoft.IIS.Administration.WebServer.Monitoring
         CounterProvider _counterProvider;
         private Dictionary<int, string> _processCounterInstances = null;
         private static readonly int _processorCount = Environment.ProcessorCount;
+        private ProcessCounterNames _processCounterNames = null;
+        private WorkerProcessCounterNames _workerProcessCounterNames = null;
+        private MemoryCounterNames _memoryCounterNames = null;
 
-        public AppPoolMonitor(CounterProvider provider)
+        public AppPoolMonitor(CounterProvider provider, ICounterTranslator translator)
         {
             _counterProvider = provider;
+            _processCounterNames = new ProcessCounterNames(translator);
+            _workerProcessCounterNames = new WorkerProcessCounterNames(translator);
+            _memoryCounterNames = new MemoryCounterNames(translator);
         }
 
         public async Task<IEnumerable<IAppPoolSnapshot>> GetSnapshots(IEnumerable<ApplicationPool> pools)
         {
             if (_processCounterInstances == null) {
-                _processCounterInstances = await ProcessUtil.GetProcessCounterMap(_counterProvider, "W3WP");
+                _processCounterInstances = await ProcessUtil.GetProcessCounterMap(_processCounterNames, _counterProvider, "W3WP");
             }
 
             var snapshots = new List<IAppPoolSnapshot>();
@@ -48,102 +54,90 @@ namespace Microsoft.IIS.Administration.WebServer.Monitoring
 
             foreach (IPerfCounter counter in await Query(pool)) {
 
-                if (counter.CategoryName.Equals(WorkerProcessCounterNames.Category)) {
-                    switch (counter.Name) {
-                        case WorkerProcessCounterNames.ActiveRequests:
-                            snapshot.ActiveRequests += counter.Value;
-                            break;
-                        case WorkerProcessCounterNames.RequestsSec:
-                            snapshot.RequestsSec += counter.Value;
-                            break;
-                        case WorkerProcessCounterNames.TotalRequests:
-                            snapshot.TotalRequests += counter.Value;
-                            break;
-                        case WorkerProcessCounterNames.CurrentFileCacheMemoryUsage:
-                            snapshot.FileCacheMemoryUsage += counter.Value;
-                            break;
-                        case WorkerProcessCounterNames.CurrentFilesCached:
-                            snapshot.CurrentFilesCached += counter.Value;
-                            break;
-                        case WorkerProcessCounterNames.CurrentUrisCached:
-                            snapshot.CurrentUrisCached += counter.Value;
-                            break;
-                        case WorkerProcessCounterNames.FileCacheHits:
-                            snapshot.FileCacheHits += counter.Value;
-                            break;
-                        case WorkerProcessCounterNames.FileCacheMisses:
-                            snapshot.FileCacheMisses += counter.Value;
-                            break;
-                        case WorkerProcessCounterNames.OutputCacheCurrentItems:
-                            snapshot.OutputCacheCurrentItems += counter.Value;
-                            break;
-                        case WorkerProcessCounterNames.OutputCacheCurrentMemoryUsage:
-                            snapshot.OutputCacheCurrentMemoryUsage += counter.Value;
-                            break;
-                        case WorkerProcessCounterNames.OutputCacheTotalHits:
-                            snapshot.OutputCacheTotalHits += counter.Value;
-                            break;
-                        case WorkerProcessCounterNames.OutputCacheTotalMisses:
-                            snapshot.OutputCacheTotalMisses += counter.Value;
-                            break;
-                        case WorkerProcessCounterNames.TotalFilesCached:
-                            snapshot.TotalFilesCached += counter.Value;
-                            break;
-                        case WorkerProcessCounterNames.TotalUrisCached:
-                            snapshot.TotalUrisCached += counter.Value;
-                            break;
-                        case WorkerProcessCounterNames.UriCacheHits:
-                            snapshot.UriCacheHits += counter.Value;
-                            break;
-                        case WorkerProcessCounterNames.UriCacheMisses:
-                            snapshot.UriCacheMisses += counter.Value;
-                            break;
-                        default:
-                            break;
+                if (counter.CategoryName.Equals(_workerProcessCounterNames.Category)) {
+                    if (counter.Name == _workerProcessCounterNames.ActiveRequests) {
+                        snapshot.ActiveRequests += counter.Value;
+                    }
+                    else if (counter.Name == _workerProcessCounterNames.RequestsSec) {
+                        snapshot.RequestsSec += counter.Value;
+                    }
+                    else if (counter.Name == _workerProcessCounterNames.TotalRequests) {
+                        snapshot.TotalRequests += counter.Value;
+                    }
+                    else if (counter.Name == _workerProcessCounterNames.CurrentFileCacheMemoryUsage) {
+                        snapshot.FileCacheMemoryUsage += counter.Value;
+                    }
+                    else if (counter.Name == _workerProcessCounterNames.CurrentFilesCached) {
+                        snapshot.CurrentFilesCached += counter.Value;
+                    }
+                    else if (counter.Name == _workerProcessCounterNames.CurrentUrisCached) {
+                        snapshot.CurrentUrisCached += counter.Value;
+                    }
+                    else if (counter.Name == _workerProcessCounterNames.FileCacheHits) {
+                        snapshot.FileCacheHits += counter.Value;
+                    }
+                    else if (counter.Name == _workerProcessCounterNames.FileCacheMisses) {
+                        snapshot.FileCacheMisses += counter.Value;
+                    }
+                    else if (counter.Name == _workerProcessCounterNames.OutputCacheCurrentItems) {
+                        snapshot.OutputCacheCurrentItems += counter.Value;
+                    }
+                    else if (counter.Name == _workerProcessCounterNames.OutputCacheCurrentMemoryUsage) {
+                        snapshot.OutputCacheCurrentMemoryUsage += counter.Value;
+                    }
+                    else if (counter.Name == _workerProcessCounterNames.OutputCacheTotalHits) {
+                        snapshot.OutputCacheTotalHits += counter.Value;
+                    }
+                    else if (counter.Name == _workerProcessCounterNames.OutputCacheTotalMisses) {
+                        snapshot.OutputCacheTotalMisses += counter.Value;
+                    }
+                    else if (counter.Name == _workerProcessCounterNames.TotalFilesCached) {
+                        snapshot.TotalFilesCached += counter.Value;
+                    }
+                    else if (counter.Name == _workerProcessCounterNames.TotalUrisCached) {
+                        snapshot.TotalUrisCached += counter.Value;
+                    }
+                    else if (counter.Name == _workerProcessCounterNames.UriCacheHits) {
+                        snapshot.UriCacheHits += counter.Value;
+                    }
+                    else if (counter.Name == _workerProcessCounterNames.UriCacheMisses) {
+                        snapshot.UriCacheMisses += counter.Value;
                     }
                 }
 
-                else if (counter.CategoryName.Equals(ProcessCounterNames.Category)) {
-                    switch (counter.Name) {
-                        case ProcessCounterNames.PercentCpu:
-                            snapshot.PercentCpuTime += counter.Value;
-                            break;
-                        case ProcessCounterNames.HandleCount:
-                            snapshot.HandleCount += counter.Value;
-                            break;
-                        case ProcessCounterNames.PrivateBytes:
-                            snapshot.PrivateBytes += counter.Value;
-                            break;
-                        case ProcessCounterNames.ThreadCount:
-                            snapshot.ThreadCount += counter.Value;
-                            break;
-                        case ProcessCounterNames.PrivateWorkingSet:
-                            snapshot.PrivateWorkingSet += counter.Value;
-                            break;
-                        case ProcessCounterNames.WorkingSet:
-                            snapshot.WorkingSet += counter.Value;
-                            break;
-                        case ProcessCounterNames.IOReadSec:
-                            snapshot.IOReadSec += counter.Value;
-                            break;
-                        case ProcessCounterNames.IOWriteSec:
-                            snapshot.IOWriteSec += counter.Value;
-                            break;
-                        case ProcessCounterNames.PageFaultsSec:
-                            snapshot.PageFaultsSec += counter.Value;
-                            break;
-                        default:
-                            break;
+                else if (counter.CategoryName.Equals(_processCounterNames.Category)) {
+                    if (counter.Name == _processCounterNames.PercentCpu) {
+                        snapshot.PercentCpuTime += counter.Value;
+                    }
+                    else if (counter.Name == _processCounterNames.HandleCount) {
+                        snapshot.HandleCount += counter.Value;
+                    }
+                    else if (counter.Name == _processCounterNames.PrivateBytes) {
+                        snapshot.PrivateBytes += counter.Value;
+                    }
+                    else if (counter.Name == _processCounterNames.ThreadCount) {
+                        snapshot.ThreadCount += counter.Value;
+                    }
+                    else if (counter.Name == _processCounterNames.PrivateWorkingSet) {
+                        snapshot.PrivateWorkingSet += counter.Value;
+                    }
+                    else if (counter.Name == _processCounterNames.WorkingSet) {
+                        snapshot.WorkingSet += counter.Value;
+                    }
+                    else if (counter.Name == _processCounterNames.IOReadSec) {
+                        snapshot.IOReadSec += counter.Value;
+                    }
+                    else if (counter.Name == _processCounterNames.IOWriteSec) {
+                        snapshot.IOWriteSec += counter.Value;
+                    }
+                    else if (counter.Name == _processCounterNames.PageFaultsSec) {
+                        snapshot.PageFaultsSec += counter.Value;
                     }
                 }
 
-                else if (counter.CategoryName.Equals(MemoryCounterNames.Category)) {
-                    switch (counter.Name) {
-                        case MemoryCounterNames.AvailableBytes:
-                            snapshot.AvailableMemory += counter.Value;
-                            break;
-                        default:
-                            break;
+                else if (counter.CategoryName.Equals(_memoryCounterNames.Category)) {
+                    if (counter.Name == _memoryCounterNames.AvailableBytes) {
+                        snapshot.AvailableMemory += counter.Value;
                     }
                 }
 
@@ -176,7 +170,7 @@ namespace Microsoft.IIS.Administration.WebServer.Monitoring
 
             foreach (WorkerProcess wp in wps) {
                 if (!_processCounterInstances.ContainsKey(wp.ProcessId)) {
-                    _processCounterInstances = await ProcessUtil.GetProcessCounterMap(_counterProvider, "W3WP");
+                    _processCounterInstances = await ProcessUtil.GetProcessCounterMap(_processCounterNames, _counterProvider, "W3WP");
 
                     //
                     // Counter instance doesn't exist
@@ -185,17 +179,17 @@ namespace Microsoft.IIS.Administration.WebServer.Monitoring
                     }
                 }
 
-                poolCounters.AddRange(await _counterProvider.GetCounters(ProcessCounterNames.Category, _processCounterInstances[wp.ProcessId], ProcessCounterNames.CounterNames));
+                poolCounters.AddRange(await _counterProvider.GetCounters(_processCounterNames.Category, _processCounterInstances[wp.ProcessId], _processCounterNames.CounterNames));
             }
 
             foreach (WorkerProcess wp in wps) {
                 poolCounters.AddRange(await _counterProvider.GetCounters(
-                    WorkerProcessCounterNames.Category,
+                    _workerProcessCounterNames.Category,
                     WorkerProcessCounterNames.GetInstanceName(wp.ProcessId, pool.Name),
-                    WorkerProcessCounterNames.CounterNames));
+                    _workerProcessCounterNames.CounterNames));
             }
 
-            poolCounters.AddRange( await _counterProvider.GetSingletonCounters(MemoryCounterNames.Category, MemoryCounterNames.CounterNames));
+            poolCounters.AddRange( await _counterProvider.GetSingletonCounters(_memoryCounterNames.Category, _memoryCounterNames.CounterNames));
 
             return poolCounters;
         }

--- a/src/Microsoft.IIS.Administration.WebServer.Monitoring/Core/CounterTranslator.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Monitoring/Core/CounterTranslator.cs
@@ -1,0 +1,121 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+
+namespace Microsoft.IIS.Administration.Monitoring
+{
+    using Microsoft.IIS.Administration.WebServer.Monitoring;
+    using Serilog;
+    using System.Collections.Generic;
+
+    class CounterTranslator : ICounterTranslator
+    {
+        //
+        // Performance counter entries can be duplicated so that indexes for an english performance counter name are ambiguous
+        // A lookup must be created
+        // https://support.microsoft.com/en-us/help/287159/using-pdh-apis-correctly-in-a-localized-language
+
+        private Dictionary<string, List<int>> _map = null;
+        private Dictionary<int, string> _lookup = null;
+        private Dictionary<string, IEnumerable<string>> _counters = new Dictionary<string, IEnumerable<string>>();
+        private CounterFinder _finder = new CounterFinder();
+
+        public string TranslateCategory(string counterName)
+        {
+            if (_map == null) {
+                BuildLookup();
+            }
+
+            string translated = null;
+
+            if (_map.TryGetValue(counterName, out List<int> indexes)) {
+
+                if (indexes.Count > 1) {
+                    Log.Error("Ambiguous translation for performance counter category");
+                }
+
+                translated = CounterUtil.LookupName((uint)indexes[0]);
+            }
+
+            return !string.IsNullOrEmpty(translated) ? translated : counterName;
+        }
+
+        public string TranslateCounterName(string category, string counterName)
+        {
+            string translated = null;
+
+            if (_map == null) {
+                BuildLookup();
+            }
+
+            //
+            // If not in map no translation available
+            if (!_map.TryGetValue(counterName, out List<int> indexes)) {
+
+                return counterName;
+
+            }
+
+            //
+            // Simple case is no ambiguity
+            if (indexes.Count == 1) {
+                translated = _lookup[indexes[0]];
+            }
+
+            if (translated == null) {
+
+                //
+                // Handle ambiguity by performing match to translated counter names for the category
+
+                string translatedCategory = TranslateCategory(category);
+
+                if (!_counters.TryGetValue(translatedCategory, out IEnumerable<string> counterNames)) {
+                    counterNames = _counters[translatedCategory] = _finder.GetCounterNames(translatedCategory);
+                }
+
+                foreach (string name in counterNames) {
+
+                    foreach (int index in indexes) {
+
+                        string indexedName = _lookup[index];
+
+                        //
+                        // The lookup points to a counter that is in the category, this is the target counter name
+                        if (indexedName.Equals(name)) {
+
+                            translated = indexedName;
+                        }
+                    }
+                }
+
+            }
+
+            if (string.IsNullOrEmpty(translated)) {
+
+                //
+                // Counter not translatable
+                Log.Information($"Could not translate counter: {category}\\{counterName}");
+
+                return counterName;
+            }
+
+            return translated;
+        }
+
+        private void BuildLookup()
+        {
+            var map = CounterUtil.GetCounterIdMap();
+            var lookup = new Dictionary<int, string>();
+
+            foreach (var kvp in map) {
+
+                foreach (var index in kvp.Value) {
+                    lookup[index] = CounterUtil.LookupName((uint)index);
+                }
+            }
+
+            _map = map;
+            _lookup = lookup;
+        }
+    }
+}

--- a/src/Microsoft.IIS.Administration.WebServer.Monitoring/Core/ICounterTranslator.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Monitoring/Core/ICounterTranslator.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+
+namespace Microsoft.IIS.Administration.Monitoring
+{
+    public interface ICounterTranslator
+    {
+        string TranslateCategory(string counterName);
+
+        string TranslateCounterName(string category, string counterName);
+    }
+}

--- a/src/Microsoft.IIS.Administration.WebServer.Monitoring/Core/Interop.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Monitoring/Core/Interop.cs
@@ -6,6 +6,7 @@ namespace Microsoft.IIS.Administration.Monitoring
 {
     using System;
     using System.Runtime.InteropServices;
+    using System.Text;
 
     public abstract class SafeHandleZeroOrMinusOneIsInvalid : SafeHandle
     {
@@ -101,6 +102,14 @@ namespace Microsoft.IIS.Administration.Monitoring
         PDH_NOEXPANDINSTANCES  = 2
     }
 
+    public enum PdhdetailLevel
+    {
+        PERF_DETAIL_NOVICE = 100,
+        PERF_DETAIL_ADVANCED = 200,
+        PERF_DETAIL_EXPERT = 300,
+        PERF_DETAIL_WIZARD = 400
+    }
+
     class Pdh
     {
         private const string PerformanceCounterLib = "pdh.dll";
@@ -168,12 +177,32 @@ namespace Microsoft.IIS.Administration.Monitoring
             IntPtr lpdwType,
             out PDH_FMT_COUNTERVALUE pValue);
 
-        [DllImport(PerformanceCounterLib, SetLastError = true, CharSet = CharSet.Ansi)]
-        public static extern UInt32 PdhExpandWildCardPathA(
+        [DllImport(PerformanceCounterLib, SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern UInt32 PdhExpandWildCardPathW(
             string szdataSource,
             string szWildCardPath,
             IntPtr mszExpandedPathList,
             ref long pcchPathListLength,
             PdhExpansionFlags dwFlags);
+
+        [DllImport(PerformanceCounterLib, SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern UInt32 PdhLookupPerfNameByIndexW(
+            string szMachineName,
+            uint dwNameIndex,
+            StringBuilder szNameBuffer,
+            ref uint pcchNameBufferSize);
+
+        [DllImport(PerformanceCounterLib, SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern UInt32 PdhEnumObjectItemsW(
+          string szDataSource,
+          string szMachineName,
+          string szObjectName,
+          IntPtr mszCounterList,
+          ref long pcchCounterListLength,
+          IntPtr mszInstanceList,
+          ref long pcchInstanceListLength,
+          PdhdetailLevel dwDetailLevel,
+          uint dwFlags
+        );
     }
 }

--- a/src/Microsoft.IIS.Administration.WebServer.Monitoring/CounterNames.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Monitoring/CounterNames.cs
@@ -2,76 +2,250 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 
+using Microsoft.IIS.Administration.Monitoring;
+
 namespace Microsoft.IIS.Administration.WebServer.Monitoring
 {
-    static class ProcessCounterNames
+    class ProcessCounterNames
     {
-        public const string Category = "Process";
-        public const string PercentCpu = "% Processor Time";
-        public const string PrivateWorkingSet = "Working Set - Private";
-        public const string WorkingSet = "Working Set";
-        public const string VirtualBytes = "Virtual Bytes";
-        public const string PrivateBytes = "Private Bytes";
-        public const string ThreadCount = "Thread Count";
-        public const string IOReadSec = "IO Read Operations/sec";
-        public const string IOWriteSec = "IO Write Operations/sec";
-        public const string ProcessId = "Id Process";
-        public const string HandleCount = "Handle Count";
-        public const string PageFaultsSec = "Page Faults/sec";
+        private const string _enCategory = "Process";
+        private const string _enPercentCpu = "% Processor Time";
+        private const string _enPrivateWorkingSet = "Working Set - Private";
+        private const string _enWorkingSet = "Working Set";
+        private const string _enVirtualBytes = "Virtual Bytes";
+        private const string _enPrivateBytes = "Private Bytes";
+        private const string _enThreadCount = "Thread Count";
+        private const string _enIOReadSec = "IO Read Operations/sec";
+        private const string _enIOWriteSec = "IO Write Operations/sec";
+        private const string _enProcessId = "ID Process";
+        private const string _enHandleCount = "Handle Count";
+        private const string _enPageFaultsSec = "Page Faults/sec";
 
-        public static readonly string[] CounterNames = new string[] {
-            PercentCpu,
-            PrivateWorkingSet,
-            WorkingSet,
-            VirtualBytes,
-            PrivateBytes,
-            ThreadCount,
-            IOReadSec,
-            IOWriteSec,
-            ProcessId,
-            HandleCount,
-            PageFaultsSec
-        };
+        private static string _category = null;
+        private static string _percentCpu = null;
+        private static string _privateWorkingSet = null;
+        private static string _workingSet = null;
+        private static string _virtualBytes = null;
+        private static string _privateBytes = null;
+        private static string _threadCount = null;
+        private static string _ioReadSec = null;
+        private static string _ioWriteSec = null;
+        private static string _processId = null;
+        private static string _handleCount = null;
+        private static string _pageFaultsSec = null;
+
+        private static string[] _counterNames = null;
+
+        public string Category { get { return _category; } }
+
+        public string PercentCpu { get { return _percentCpu; } }
+
+        public string PrivateWorkingSet { get { return _privateWorkingSet; } }
+
+        public string WorkingSet { get { return _workingSet; } }
+
+        public string VirtualBytes { get { return _virtualBytes; } }
+
+        public string PrivateBytes { get { return _privateBytes; } }
+
+        public string ThreadCount { get { return _threadCount; } }
+
+        public string IOReadSec { get { return _ioReadSec; } }
+
+        public string IOWriteSec { get { return _ioWriteSec; } }
+
+        public string ProcessId { get { return _processId; } }
+
+        public string HandleCount { get { return _handleCount; } }
+
+        public string PageFaultsSec { get { return _pageFaultsSec; } }
+
+        public string[] CounterNames { get { return _counterNames; } }
+
+        public ProcessCounterNames(ICounterTranslator translator)
+        {
+            if (_counterNames == null) {
+                string category = translator.TranslateCategory(_enCategory);
+                string percentCpu = translator.TranslateCounterName(_enCategory, _enPercentCpu);
+                string privateWorkingSet = translator.TranslateCounterName(_enCategory, _enPrivateWorkingSet);
+                string workingSet = translator.TranslateCounterName(_enCategory, _enWorkingSet);
+                string virtualBytes = translator.TranslateCounterName(_enCategory, _enVirtualBytes);
+                string privateBytes = translator.TranslateCounterName(_enCategory, _enPrivateBytes);
+                string threadCount = translator.TranslateCounterName(_enCategory, _enThreadCount);
+                string ioReadSec = translator.TranslateCounterName(_enCategory, _enIOReadSec);
+                string ioWriteSec = translator.TranslateCounterName(_enCategory, _enIOWriteSec);
+                string processId = translator.TranslateCounterName(_enCategory, _enProcessId);
+                string handleCount = translator.TranslateCounterName(_enCategory, _enHandleCount);
+                string pageFaultsSec = translator.TranslateCounterName(_enCategory, _enPageFaultsSec);
+
+                var names = new string[] {
+                    percentCpu,
+                    privateWorkingSet,
+                    workingSet,
+                    virtualBytes,
+                    privateBytes,
+                    threadCount,
+                    ioReadSec,
+                    ioWriteSec,
+                    processId,
+                    handleCount,
+                    pageFaultsSec
+                };
+
+                _category = category;
+                _percentCpu = percentCpu;
+                _privateWorkingSet = privateWorkingSet;
+                _workingSet = workingSet;
+                _virtualBytes = virtualBytes;
+                _privateBytes = privateBytes;
+                _threadCount = threadCount;
+                _ioReadSec = ioReadSec;
+                _ioWriteSec = ioWriteSec;
+                _processId = processId;
+                _handleCount = handleCount;
+                _pageFaultsSec = pageFaultsSec;
+
+                _counterNames = names;
+            }
+        }
     }
 
-    static class WorkerProcessCounterNames
+    class WorkerProcessCounterNames
     {
-        public const string Category = "W3SVC_W3WP";
-        public const string ActiveRequests = "Active Requests";
-        public const string RequestsSec = "Requests / Sec";
-        public const string TotalRequests = "Total HTTP Requests Served";
-        public const string CurrentFileCacheMemoryUsage = "Current File Cache Memory Usage";
-        public const string CurrentFilesCached = "Current Files Cached";
-        public const string CurrentUrisCached = "Current URIs Cached";
-        public const string FileCacheHits = "File Cache Hits";
-        public const string FileCacheMisses = "File Cache Misses";
-        public const string OutputCacheCurrentItems = "Output Cache Current Items";
-        public const string OutputCacheCurrentMemoryUsage = "Output Cache Current Memory Usage";
-        public const string OutputCacheTotalHits = "Output Cache Total Hits";
-        public const string OutputCacheTotalMisses = "Output Cache Total Misses";
-        public const string TotalFilesCached = "Total Files Cached";
-        public const string TotalUrisCached = "Total URIs Cached";
-        public const string UriCacheHits = "URI Cache Hits";
-        public const string UriCacheMisses = "URI Cache Misses";
+        private const string _enCategory = "W3SVC_W3WP";
+        private const string _enActiveRequests = "Active Requests";
+        private const string _enRequestsSec = "Requests / Sec";
+        private const string _enTotalRequests = "Total HTTP Requests Served";
+        private const string _enCurrentFileCacheMemoryUsage = "Current File Cache Memory Usage";
+        private const string _enCurrentFilesCached = "Current Files Cached";
+        private const string _enCurrentUrisCached = "Current URIs Cached";
+        private const string _enFileCacheHits = "File Cache Hits";
+        private const string _enFileCacheMisses = "File Cache Misses";
+        private const string _enOutputCacheCurrentItems = "Output Cache Current Items";
+        private const string _enOutputCacheCurrentMemoryUsage = "Output Cache Current Memory Usage";
+        private const string _enOutputCacheTotalHits = "Output Cache Total Hits";
+        private const string _enOutputCacheTotalMisses = "Output Cache Total Misses";
+        private const string _enTotalFilesCached = "Total Files Cached";
+        private const string _enTotalUrisCached = "Total URIs Cached";
+        private const string _enUriCacheHits = "URI Cache Hits";
+        private const string _enUriCacheMisses = "URI Cache Misses";
 
-        public static readonly string[] CounterNames = new string[] {
-            ActiveRequests,
-            RequestsSec,
-            TotalRequests,
-            CurrentFileCacheMemoryUsage,
-            CurrentFilesCached,
-            CurrentUrisCached,
-            FileCacheHits,
-            FileCacheMisses,
-            OutputCacheCurrentItems,
-            OutputCacheCurrentMemoryUsage,
-            OutputCacheTotalHits,
-            OutputCacheTotalMisses,
-            TotalFilesCached,
-            TotalUrisCached,
-            UriCacheHits,
-            UriCacheMisses
-        };
+        private static string _category = null;
+        private static string _activeRequests = null;
+        private static string _requestsSec = null;
+        private static string _totalRequests = null;
+        private static string _currentFileCacheMemoryUsage = null;
+        private static string _currentFilesCached = null;
+        private static string _currentUrisCached = null;
+        private static string _fileCacheHits = null;
+        private static string _fileCacheMisses = null;
+        private static string _outputCacheCurrentItems = null;
+        private static string _outputCacheCurrentMemoryUsage = null;
+        private static string _outputCacheTotalHits = null;
+        private static string _outputCacheTotalMisses = null;
+        private static string _totalFilesCached = null;
+        private static string _totalUrisCached = null;
+        private static string _uriCacheHits = null;
+        private static string _uriCacheMisses = null;
+        private static string[] _counterNames = null;
+
+        public string Category { get { return _category; } }
+
+        public string ActiveRequests { get { return _activeRequests; } }
+
+        public string RequestsSec { get { return _requestsSec; } }
+
+        public string TotalRequests { get { return _totalRequests; } }
+
+        public string CurrentFileCacheMemoryUsage { get { return _currentFileCacheMemoryUsage; } }
+
+        public string CurrentFilesCached { get { return _currentFilesCached; } }
+
+        public string CurrentUrisCached { get { return _currentUrisCached; } }
+
+        public string FileCacheHits { get { return _fileCacheHits; } }
+
+        public string FileCacheMisses { get { return _fileCacheMisses; } }
+
+        public string OutputCacheCurrentItems { get { return _outputCacheCurrentItems; } }
+
+        public string OutputCacheCurrentMemoryUsage { get { return _outputCacheCurrentMemoryUsage; } }
+
+        public string OutputCacheTotalHits { get { return _outputCacheTotalHits; } }
+
+        public string OutputCacheTotalMisses { get { return _outputCacheTotalMisses; } }
+
+        public string TotalFilesCached { get { return _totalFilesCached; } }
+
+        public string TotalUrisCached { get { return _totalUrisCached; } }
+
+        public string UriCacheHits { get { return _uriCacheHits; } }
+
+        public string UriCacheMisses { get { return _uriCacheMisses; } }
+
+        public string[] CounterNames { get { return _counterNames; } }
+
+        public WorkerProcessCounterNames(ICounterTranslator translator)
+        {
+            if (_counterNames == null) {
+                string category = translator.TranslateCategory(_enCategory);
+                string activeRequests = translator.TranslateCounterName(_enCategory, _enActiveRequests);
+                string requestsSec = translator.TranslateCounterName(_enCategory, _enRequestsSec);
+                string totalRequests = translator.TranslateCounterName(_enCategory, _enTotalRequests);
+                string currentFileCacheMemoryUsage = translator.TranslateCounterName(_enCategory, _enCurrentFileCacheMemoryUsage);
+                string currentFilesCached = translator.TranslateCounterName(_enCategory, _enCurrentFilesCached);
+                string currentUrisCached = translator.TranslateCounterName(_enCategory, _enCurrentUrisCached);
+                string fileCacheHits = translator.TranslateCounterName(_enCategory, _enFileCacheHits);
+                string fileCacheMisses = translator.TranslateCounterName(_enCategory, _enFileCacheMisses);
+                string outputCacheCurrentItems = translator.TranslateCounterName(_enCategory, _enOutputCacheCurrentItems);
+                string outputCacheCurrentMemoryUsage = translator.TranslateCounterName(_enCategory, _enOutputCacheCurrentMemoryUsage);
+                string outputCacheTotalHits = translator.TranslateCounterName(_enCategory, _enOutputCacheTotalHits);
+                string outputCacheTotalMisses = translator.TranslateCounterName(_enCategory, _enOutputCacheTotalMisses);
+                string totalFilesCached = translator.TranslateCounterName(_enCategory, _enTotalFilesCached);
+                string totalUrisCached = translator.TranslateCounterName(_enCategory, _enTotalUrisCached);
+                string uriCacheHits = translator.TranslateCounterName(_enCategory, _enUriCacheHits);
+                string uriCacheMisses = translator.TranslateCounterName(_enCategory, _enUriCacheMisses);
+
+                var names = new string[] {
+                    activeRequests,
+                    requestsSec,
+                    totalRequests,
+                    currentFileCacheMemoryUsage,
+                    currentFilesCached,
+                    currentUrisCached,
+                    fileCacheHits,
+                    fileCacheMisses,
+                    outputCacheCurrentItems,
+                    outputCacheCurrentMemoryUsage,
+                    outputCacheTotalHits,
+                    outputCacheTotalMisses,
+                    totalFilesCached,
+                    totalUrisCached,
+                    uriCacheHits,
+                    uriCacheMisses
+                };
+
+                _category = category;
+                _activeRequests = activeRequests;
+                _requestsSec = requestsSec;
+                _totalRequests = totalRequests;
+                _currentFileCacheMemoryUsage = currentFileCacheMemoryUsage;
+                _currentFilesCached = currentFilesCached;
+                _currentUrisCached = currentUrisCached;
+                _fileCacheHits = fileCacheHits;
+                _fileCacheMisses = fileCacheMisses;
+                _outputCacheCurrentItems = outputCacheCurrentItems;
+                _outputCacheCurrentMemoryUsage = outputCacheCurrentMemoryUsage;
+                _outputCacheTotalHits = outputCacheTotalHits;
+                _outputCacheTotalMisses = outputCacheTotalMisses;
+                _totalFilesCached = totalFilesCached;
+                _totalUrisCached = totalUrisCached;
+                _uriCacheHits = uriCacheHits;
+                _uriCacheMisses = uriCacheMisses;
+
+                _counterNames = names;
+            }
+        }
 
         public static string GetInstanceName(int processId, string appPoolName)
         {
@@ -79,89 +253,296 @@ namespace Microsoft.IIS.Administration.WebServer.Monitoring
         }
     }
 
-    static class WebSiteCounterNames
+    class WebSiteCounterNames
     {
-        public const string Category = "Web Service";
-        public const string ServiceUptime = "Service Uptime";
-        public const string BytesRecvSec = "Bytes Received/sec";
-        public const string BytesSentSec = "Bytes Sent/sec";
-        public const string TotalBytesSent = "Total Bytes Sent";
-        public const string TotalBytesRecv = "Total Bytes Received";
-        public const string ConnectionAttemptsSec = "Connection Attempts/sec";
-        public const string CurrentConnections = "Current Connections";
-        public const string TotalConnectionAttempts = "Total Connection Attempts (all instances)";
-        public const string TotalMethodRequestsSec = "Total Method Requests/sec";
-        public const string TotalOtherMethodRequestsSec = "Other Request Methods/sec";
-        public const string TotalMethodRequests = "Total Method Requests";
-        public const string TotalOtherMethodRequests = "Total Other Request Methods";
+        private const string _enCategory = "Web Service";
+        private const string _enServiceUptime = "Service Uptime";
+        private const string _enBytesRecvSec = "Bytes Received/sec";
+        private const string _enBytesSentSec = "Bytes Sent/sec";
+        private const string _enTotalBytesSent = "Total Bytes Sent";
+        private const string _enTotalBytesRecv = "Total Bytes Received";
+        private const string _enConnectionAttemptsSec = "Connection Attempts/sec";
+        private const string _enCurrentConnections = "Current Connections";
+        private const string _enTotalConnectionAttempts = "Total Connection Attempts (all instances)";
+        private const string _enTotalMethodRequestsSec = "Total Method Requests/sec";
+        private const string _enTotalOtherMethodRequestsSec = "Other Request Methods/sec";
+        private const string _enTotalMethodRequests = "Total Method Requests";
+        private const string _enTotalOtherMethodRequests = "Total Other Request Methods";
 
-        public static readonly string[] CounterNames = new string[] {
-            ServiceUptime,
-            BytesRecvSec,
-            BytesSentSec,
-            TotalBytesRecv,
-            TotalBytesSent,
-            ConnectionAttemptsSec,
-            CurrentConnections,
-            TotalConnectionAttempts,
-            TotalMethodRequestsSec,
-            TotalOtherMethodRequestsSec,
-            TotalMethodRequests,
-            TotalOtherMethodRequests
-        };
+        private static string _category = null;
+        private static string _serviceUptime = null;
+        private static string _bytesRecvSec = null;
+        private static string _bytesSentSec = null;
+        private static string _totalBytesSent = null;
+        private static string _totalBytesRecv = null;
+        private static string _connectionAttemptsSec = null;
+        private static string _currentConnections = null;
+        private static string _totalConnectionAttempts = null;
+        private static string _totalMethodRequestsSec = null;
+        private static string _totalOtherMethodRequestsSec = null;
+        private static string _totalMethodRequests = null;
+        private static string _totalOtherMethodRequests = null;
+        private static string[] _counterNames = null;
+
+        public string Category { get { return _category; } }
+
+        public string ServiceUptime { get { return _serviceUptime; } }
+
+        public string BytesRecvSec { get { return _bytesRecvSec; } }
+
+        public string BytesSentSec { get { return _bytesSentSec; } }
+
+        public string TotalBytesSent { get { return _totalBytesSent; } }
+
+        public string TotalBytesRecv { get { return _totalBytesRecv; } }
+
+        public string ConnectionAttemptsSec { get { return _connectionAttemptsSec; } }
+
+        public string CurrentConnections { get { return _currentConnections; } }
+
+        public string TotalConnectionAttempts { get { return _totalConnectionAttempts; } }
+
+        public string TotalMethodRequestsSec { get { return _totalMethodRequestsSec; } }
+
+        public string TotalOtherMethodRequestsSec { get { return _totalOtherMethodRequestsSec; } }
+
+        public string TotalMethodRequests { get { return _totalMethodRequests; } }
+
+        public string TotalOtherMethodRequests { get { return _totalOtherMethodRequests; } }
+
+        public string[] CounterNames { get { return _counterNames; } }
+
+        public WebSiteCounterNames(ICounterTranslator translator)
+        {
+            if (_counterNames == null) {
+                string category = translator.TranslateCategory(_enCategory);
+                string serviceUptime = translator.TranslateCounterName(_enCategory, _enServiceUptime);
+                string bytesRecvSec = translator.TranslateCounterName(_enCategory, _enBytesRecvSec);
+                string bytesSentSec = translator.TranslateCounterName(_enCategory, _enBytesSentSec);
+                string totalBytesSent = translator.TranslateCounterName(_enCategory, _enTotalBytesSent);
+                string totalBytesRecv = translator.TranslateCounterName(_enCategory, _enTotalBytesRecv);
+                string connectionAttemptsSec = translator.TranslateCounterName(_enCategory, _enConnectionAttemptsSec);
+                string currentConnections = translator.TranslateCounterName(_enCategory, _enCurrentConnections);
+                string totalConnectionAttempts = translator.TranslateCounterName(_enCategory, _enTotalConnectionAttempts);
+                string totalMethodRequestsSec = translator.TranslateCounterName(_enCategory, _enTotalMethodRequestsSec);
+                string totalOtherMethodRequestsSec = translator.TranslateCounterName(_enCategory, _enTotalOtherMethodRequestsSec);
+                string totalMethodRequests = translator.TranslateCounterName(_enCategory, _enTotalMethodRequests);
+                string totalOtherMethodRequests = translator.TranslateCounterName(_enCategory, _enTotalOtherMethodRequests);
+
+                var names = new string[] {
+                    serviceUptime,
+                    bytesRecvSec,
+                    bytesSentSec,
+                    totalBytesSent,
+                    totalBytesRecv,
+                    connectionAttemptsSec,
+                    currentConnections,
+                    totalConnectionAttempts,
+                    totalMethodRequestsSec,
+                    totalOtherMethodRequestsSec,
+                    totalMethodRequests,
+                    totalOtherMethodRequests
+                };
+
+                _category = category;
+                _serviceUptime = serviceUptime;
+                _bytesRecvSec = bytesRecvSec;
+                _bytesSentSec = bytesSentSec;
+                _totalBytesSent = totalBytesSent;
+                _totalBytesRecv = totalBytesRecv;
+                _connectionAttemptsSec = connectionAttemptsSec;
+                _currentConnections = currentConnections;
+                _totalConnectionAttempts = totalConnectionAttempts;
+                _totalMethodRequestsSec = totalMethodRequestsSec;
+                _totalOtherMethodRequestsSec = totalOtherMethodRequestsSec;
+                _totalMethodRequests = totalMethodRequests;
+                _totalOtherMethodRequests = totalOtherMethodRequests;
+
+                _counterNames = names;
+            }
+        }
     }
 
-    static class MemoryCounterNames
+    class MemoryCounterNames
     {
-        public const string Category = "Memory";
-        public const string AvailableBytes = "Available Bytes";
+        private const string _enCategory = "Memory";
+        private const string _enAvailableBytes = "Available Bytes";
 
-        public static readonly string[] CounterNames = new string[] {
-            AvailableBytes
-        };
+        private static string _category = null;
+        private static string _availableBytes = null;
+        private static string[] _counterNames = null;
+
+        public string Category { get { return _category; } }
+
+        public string AvailableBytes { get { return _availableBytes; } }
+
+        public string[] CounterNames { get { return _counterNames; } }
+
+        public MemoryCounterNames(ICounterTranslator translator)
+        {
+            if (_counterNames == null) {
+                string category = translator.TranslateCategory(_enCategory);
+                string availableBytes = translator.TranslateCounterName(_enCategory, _enAvailableBytes);
+
+                string[] names = new string[] {
+                    availableBytes
+                };
+
+                _category = category;
+                _availableBytes = availableBytes;
+
+                _counterNames = names;
+            }
+        }
     }
 
-    static class CacheCounterNames
+    class CacheCounterNames
     {
-        public const string Category = "Web Service Cache";
-        public const string CurrentFileCacheMemoryUsage = "Current File Cache Memory Usage";
-        public const string CurrentFilesCached = "Current Files Cached";
-        public const string CurrentUrisCached = "Current URIs Cached";
-        public const string FileCacheHits = "File Cache Hits";
-        public const string FileCacheMisses = "File Cache Misses";
-        public const string OutputCacheCurrentItems = "Output Cache Current Items";
-        public const string OutputCacheCurrentMemoryUsage = "Output Cache Current Memory Usage";
-        public const string OutputCacheTotalHits = "Output Cache Total Hits";
-        public const string OutputCacheTotalMisses = "Output Cache Total Misses";
-        public const string TotalFilesCached = "Total Files Cached";
-        public const string TotalUrisCached = "Total URIs Cached";
-        public const string UriCacheHits = "URI Cache Hits";
-        public const string UriCacheMisses = "URI Cache Misses";
+        private const string _enCategory = "Web Service Cache";
+        private const string _enCurrentFileCacheMemoryUsage = "Current File Cache Memory Usage";
+        private const string _enCurrentFilesCached = "Current Files Cached";
+        private const string _enCurrentUrisCached = "Current URIs Cached";
+        private const string _enFileCacheHits = "File Cache Hits";
+        private const string _enFileCacheMisses = "File Cache Misses";
+        private const string _enOutputCacheCurrentItems = "Output Cache Current Items";
+        private const string _enOutputCacheCurrentMemoryUsage = "Output Cache Current Memory Usage";
+        private const string _enOutputCacheTotalHits = "Output Cache Total Hits";
+        private const string _enOutputCacheTotalMisses = "Output Cache Total Misses";
+        private const string _enTotalFilesCached = "Total Files Cached";
+        private const string _enTotalUrisCached = "Total URIs Cached";
+        private const string _enUriCacheHits = "URI Cache Hits";
+        private const string _enUriCacheMisses = "URI Cache Misses";
 
-        public static readonly string[] CounterNames = new string[] {
-            CurrentFileCacheMemoryUsage,
-            CurrentFilesCached,
-            CurrentUrisCached,
-            FileCacheHits,
-            FileCacheMisses,
-            OutputCacheCurrentItems,
-            OutputCacheCurrentMemoryUsage,
-            OutputCacheTotalHits,
-            OutputCacheTotalMisses,
-            TotalFilesCached,
-            TotalUrisCached,
-            UriCacheHits,
-            UriCacheMisses
-        };
+        private static string _category = null;
+        private static string _currentFileCacheMemoryUsage = null;
+        private static string _currentFilesCached = null;
+        private static string _currentUrisCached = null;
+        private static string _fileCacheHits = null;
+        private static string _fileCacheMisses = null;
+        private static string _outputCacheCurrentItems = null;
+        private static string _outputCacheCurrentMemoryUsage = null;
+        private static string _outputCacheTotalHits = null;
+        private static string _outputCacheTotalMisses = null;
+        private static string _totalFilesCached = null;
+        private static string _totalUrisCached = null;
+        private static string _uriCacheHits = null;
+        private static string _uriCacheMisses = null;
+        private static string[] _counterNames = null;
+
+        public string Category { get { return _category; } }
+
+        public string CurrentFileCacheMemoryUsage { get { return _currentFileCacheMemoryUsage; } }
+
+        public string CurrentFilesCached { get { return _currentFilesCached; } }
+
+        public string CurrentUrisCached { get { return _currentUrisCached; } }
+
+        public string FileCacheHits { get { return _fileCacheHits; } }
+
+        public string FileCacheMisses { get { return _fileCacheMisses; } }
+
+        public string OutputCacheCurrentItems { get { return _outputCacheCurrentItems; } }
+
+        public string OutputCacheCurrentMemoryUsage { get { return _outputCacheCurrentMemoryUsage; } }
+
+        public string OutputCacheTotalHits { get { return _outputCacheTotalHits; } }
+
+        public string OutputCacheTotalMisses { get { return _outputCacheTotalMisses; } }
+
+        public string TotalFilesCached { get { return _totalFilesCached; } }
+
+        public string TotalUrisCached { get { return _totalUrisCached; } }
+
+        public string UriCacheHits { get { return _uriCacheHits; } }
+
+        public string UriCacheMisses { get { return _uriCacheMisses; } }
+
+        public string[] CounterNames { get { return _counterNames; } }
+
+        public CacheCounterNames(ICounterTranslator translator)
+        {
+            if (_counterNames == null) {
+                string category = translator.TranslateCategory(_enCategory);
+                string currentFileCacheMemoryUsage = translator.TranslateCounterName(_enCategory, _enCurrentFileCacheMemoryUsage);
+                string currentFilesCached = translator.TranslateCounterName(_enCategory, _enCurrentFilesCached);
+                string currentUrisCached = translator.TranslateCounterName(_enCategory, _enCurrentUrisCached);
+                string fileCacheHits = translator.TranslateCounterName(_enCategory, _enFileCacheHits);
+                string fileCacheMisses = translator.TranslateCounterName(_enCategory, _enFileCacheMisses);
+                string outputCacheCurrentItems = translator.TranslateCounterName(_enCategory, _enOutputCacheCurrentItems);
+                string outputCacheCurrentMemoryUsage = translator.TranslateCounterName(_enCategory, _enOutputCacheCurrentMemoryUsage);
+                string outputCacheTotalHits = translator.TranslateCounterName(_enCategory, _enOutputCacheTotalHits);
+                string outputCacheTotalMisses = translator.TranslateCounterName(_enCategory, _enOutputCacheTotalMisses);
+                string totalFilesCached = translator.TranslateCounterName(_enCategory, _enTotalFilesCached);
+                string totalUrisCached = translator.TranslateCounterName(_enCategory, _enTotalUrisCached);
+                string uriCacheHits = translator.TranslateCounterName(_enCategory, _enUriCacheHits);
+                string uriCacheMisses = translator.TranslateCounterName(_enCategory, _enUriCacheMisses);
+
+                var names = new string[] {
+                    currentFileCacheMemoryUsage,
+                    currentFilesCached,
+                    currentUrisCached,
+                    fileCacheHits,
+                    fileCacheMisses,
+                    outputCacheCurrentItems,
+                    outputCacheCurrentMemoryUsage,
+                    outputCacheTotalHits,
+                    outputCacheTotalMisses,
+                    totalFilesCached,
+                    totalUrisCached,
+                    uriCacheHits,
+                    uriCacheMisses
+                };
+
+                _category = category;
+                _currentFileCacheMemoryUsage = currentFileCacheMemoryUsage;
+                _currentFilesCached = currentFilesCached;
+                _currentUrisCached = currentUrisCached;
+                _fileCacheHits = fileCacheHits;
+                _fileCacheMisses = fileCacheMisses;
+                _outputCacheCurrentItems = outputCacheCurrentItems;
+                _outputCacheCurrentMemoryUsage = outputCacheCurrentMemoryUsage;
+                _outputCacheTotalHits = outputCacheTotalHits;
+                _outputCacheTotalMisses = outputCacheTotalMisses;
+                _totalFilesCached = totalFilesCached;
+                _totalUrisCached = totalUrisCached;
+                _uriCacheHits = uriCacheHits;
+                _uriCacheMisses = uriCacheMisses;
+
+                _counterNames = names;
+            }
+        }
     }
 
-    static class ProcessorCounterNames
+    class ProcessorCounterNames
     {
-        public const string Category = "Processor";
-        public const string IdleTime = "% Idle Time";
+        private const string _enCategory = "Processor";
+        private const string _enIdleTime = "% Idle Time";
 
-        public static readonly string[] CounterNames = new string[] {
-            IdleTime
-        };
+        private static string _category = "Processor";
+        private static string _idleTime = "% Idle Time";
+        private static string[] _counterNames = null;
+
+        public string Category { get { return _category; } }
+
+        public string IdleTime { get { return _idleTime; } }
+
+        public string[] CounterNames { get { return _counterNames; } }
+
+        public ProcessorCounterNames(ICounterTranslator translator)
+        {
+            if (_counterNames == null) {
+                string category = translator.TranslateCategory(_enCategory);
+                string idleTime = translator.TranslateCounterName(_enCategory, _enIdleTime);
+
+                var names = new string[] {
+                    idleTime
+                };
+
+                _category = category;
+                _idleTime = idleTime;
+
+                _counterNames = names;
+            }
+        }
     }
 }

--- a/src/Microsoft.IIS.Administration.WebServer.Monitoring/Startup.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Monitoring/Startup.cs
@@ -19,10 +19,12 @@ namespace Microsoft.IIS.Administration.WebServer.Monitoring
         public void Use(IServiceCollection services)
         {
             _provider = new CounterProvider();
-            var appPoolMonitor = new AppPoolMonitor(_provider);
-            var webserverMonitor = new WebServerMonitor(_provider);
-            var siteMonitor = new WebSiteMonitor(_provider);
+            var translator = new CounterTranslator();
+            var appPoolMonitor = new AppPoolMonitor(_provider, translator);
+            var webserverMonitor = new WebServerMonitor(_provider, translator);
+            var siteMonitor = new WebSiteMonitor(_provider, translator);
 
+            services.AddSingleton<ICounterTranslator>(translator);
             services.AddSingleton<ICounterProvider>(_provider);
             services.AddSingleton<IAppPoolMonitor>(appPoolMonitor);
             services.AddSingleton<IWebServerMonitor>(webserverMonitor);

--- a/src/Microsoft.IIS.Administration.WebServer.Monitoring/Util/CounterUtil.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Monitoring/Util/CounterUtil.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+
+namespace Microsoft.IIS.Administration.WebServer.Monitoring
+{
+    using Microsoft.IIS.Administration.Monitoring;
+    using Microsoft.Win32;
+    using System.Collections.Generic;
+    using System.ComponentModel;
+    using System.Text;
+
+    class CounterUtil
+    {
+        private const string CounterNamesRegKey = @"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Perflib\009";
+        private const string CounterNamesRegSubKey = "counter";
+
+        public static Dictionary<string, List<int>> GetCounterIdMap()
+        {
+            string[] entries = null;
+            var idMap = new Dictionary<string, List<int>>();
+
+            //
+            // 009 - English Language Id
+            using (var key = Registry.LocalMachine.OpenSubKey(CounterNamesRegKey)) {
+                entries = (string[])key?.GetValue(CounterNamesRegSubKey);
+            }
+
+            if (entries != null) {
+
+                for (int i = 0; i < entries.Length - 1; i += 2) {
+
+                    string key = entries[i + 1];
+
+                    if (int.TryParse(entries[i], out int val)) {
+
+                        if (!idMap.ContainsKey(key)) {
+
+                            idMap[key] = new List<int>() { val };
+                        }
+                        else {
+
+                            idMap[key].Add(val);
+                        }
+                    }
+                }
+            }
+
+            return idMap;
+        }
+
+        public static string LookupName(uint index)
+        {
+            uint bufSize = 0;
+
+            uint result = Pdh.PdhLookupPerfNameByIndexW(null, index, null, ref bufSize);
+
+            if (result != 0 && result != Pdh.PDH_MORE_DATA) {
+                throw new Win32Exception((int)result);
+            }
+
+            StringBuilder buffer = new StringBuilder((int)bufSize);
+
+            result = Pdh.PdhLookupPerfNameByIndexW(null, index, buffer, ref bufSize);
+
+            if (result != 0) {
+                throw new Win32Exception((int)result);
+            }
+
+            return buffer.ToString();
+        }
+    }
+}

--- a/src/Microsoft.IIS.Administration.WebServer.Monitoring/Util/ProcessUtil.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Monitoring/Util/ProcessUtil.cs
@@ -35,11 +35,11 @@ namespace Microsoft.IIS.Administration.WebServer.Monitoring
             return ids;
         }
 
-        public static async Task<IEnumerable<string>> GetProcessCounterInstances(IEnumerable<int> processIds)
+        public static async Task<IEnumerable<string>> GetProcessCounterInstances(ProcessCounterNames processCounterNames, IEnumerable<int> processIds)
         {
             const string ProcessIdentifier = "ID Process";
             var provider = new CounterFinder();
-            var processIdCounters = provider.GetCountersByName(ProcessCounterNames.Category, ProcessIdentifier);
+            var processIdCounters = provider.GetCountersByName(processCounterNames.Category, ProcessIdentifier);
 
             var targetProcessInstances = new List<string>();
 
@@ -65,18 +65,18 @@ namespace Microsoft.IIS.Administration.WebServer.Monitoring
         // Process counters instance names are not equivalent to their process IDs therefore a map must be generated to distinguish them
         // key: process id
         // value: process counter instance name
-        public static async Task<Dictionary<int, string>> GetProcessCounterMap(ICounterProvider provider, string processName)
+        public static async Task<Dictionary<int, string>> GetProcessCounterMap(ProcessCounterNames processCounterNames, ICounterProvider provider, string processName)
         {
             var counterFinder = new CounterFinder();
             var map = new Dictionary<int, string>();
 
-            var instances = counterFinder.GetInstances(ProcessCounterNames.Category).Where(instance => instance.StartsWith(processName, StringComparison.OrdinalIgnoreCase));
+            var instances = counterFinder.GetInstances(processCounterNames.Category).Where(instance => instance.StartsWith(processName, StringComparison.OrdinalIgnoreCase));
 
             List<IPerfCounter> counters = new List<IPerfCounter>();
 
             try {
                 foreach (string instance in instances) {
-                    counters.AddRange(await provider.GetCounters(ProcessCounterNames.Category, instance, ProcessCounterNames.CounterNames));
+                    counters.AddRange(await provider.GetCounters(processCounterNames.Category, instance, processCounterNames.CounterNames));
                 }
             }
             catch (MissingCountersException) {
@@ -85,7 +85,7 @@ namespace Microsoft.IIS.Administration.WebServer.Monitoring
             }
 
             foreach (IPerfCounter counter in counters) {
-                if (counter.Name.Equals(ProcessCounterNames.ProcessId)) {
+                if (counter.Name.Equals(processCounterNames.ProcessId)) {
 
                     //
                     // process id fits in int

--- a/src/Microsoft.IIS.Administration.WebServer.Monitoring/WebServer/WebServerMonitor.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Monitoring/WebServer/WebServerMonitor.cs
@@ -17,11 +17,23 @@ namespace Microsoft.IIS.Administration.WebServer.Monitoring
         private static readonly int _processorCount = Environment.ProcessorCount;
         private IEnumerable<int> _webserverProcesses;
         private CounterProvider _provider;
+        private ProcessCounterNames _processCounterNames = null;
+        private WorkerProcessCounterNames _workerProcessCounterNames = null;
+        private WebSiteCounterNames _webSiteCounterNames = null;
+        private ProcessorCounterNames _processorCounterNames = null;
+        private MemoryCounterNames _memoryCounterNames = null;
+        private CacheCounterNames _cacheCounterNames = null;
         private Dictionary<int, string> _processCounterMap;
 
-        public WebServerMonitor(CounterProvider provider)
+        public WebServerMonitor(CounterProvider provider, ICounterTranslator translator)
         {
             _provider = provider;
+            _processCounterNames = new ProcessCounterNames(translator);
+            _workerProcessCounterNames = new WorkerProcessCounterNames(translator);
+            _webSiteCounterNames = new WebSiteCounterNames(translator);
+            _processorCounterNames = new ProcessorCounterNames(translator);
+            _memoryCounterNames = new MemoryCounterNames(translator);
+            _cacheCounterNames = new CacheCounterNames(translator);
         }
 
         public async Task<IWebServerSnapshot> GetSnapshot()
@@ -65,153 +77,129 @@ namespace Microsoft.IIS.Administration.WebServer.Monitoring
             long uriCacheMisses = 0;
 
             foreach (IPerfCounter counter in counters) {
-                if (counter.CategoryName.Equals(WebSiteCounterNames.Category)) {
-                    switch (counter.Name) {
-                        case WebSiteCounterNames.BytesRecvSec:
-                            bytesRecvSec += counter.Value;
-                            break;
-                        case WebSiteCounterNames.BytesSentSec:
-                            bytesSentSec += counter.Value;
-                            break;
-                        case WebSiteCounterNames.TotalBytesRecv:
-                            totalBytesRecv += counter.Value;
-                            break;
-                        case WebSiteCounterNames.TotalBytesSent:
-                            totalBytesSent += counter.Value;
-                            break;
-                        case WebSiteCounterNames.ConnectionAttemptsSec:
-                            connectionAttemptsSec += counter.Value;
-                            break;
-                        case WebSiteCounterNames.TotalConnectionAttempts:
-                            totalConnectionAttempts += counter.Value;
-                            break;
-                        case WebSiteCounterNames.CurrentConnections:
-                            currentConnections += counter.Value;
-                            break;
-                        case WebSiteCounterNames.TotalMethodRequestsSec:
-                            requestsSec += counter.Value;
-                            break;
-                        case WebSiteCounterNames.TotalOtherMethodRequestsSec:
-                            requestsSec += counter.Value;
-                            break;
-                        case WebSiteCounterNames.TotalMethodRequests:
-                            totalRequests += counter.Value;
-                            break;
-                        case WebSiteCounterNames.TotalOtherMethodRequests:
-                            totalRequests += counter.Value;
-                            break;
-                        default:
-                            break;
+                if (counter.CategoryName.Equals(_webSiteCounterNames.Category)) {
+                    if (counter.Name == _webSiteCounterNames.BytesRecvSec) {
+                        bytesRecvSec += counter.Value;
+                    }
+                    else if (counter.Name == _webSiteCounterNames.BytesSentSec) {
+                        bytesSentSec += counter.Value;
+                    }
+                    else if (counter.Name == _webSiteCounterNames.TotalBytesRecv) {
+                        totalBytesRecv += counter.Value;
+                    }
+                    else if (counter.Name == _webSiteCounterNames.TotalBytesSent) {
+                        totalBytesSent += counter.Value;
+                    }
+                    else if (counter.Name == _webSiteCounterNames.ConnectionAttemptsSec) {
+                        connectionAttemptsSec += counter.Value;
+                    }
+                    else if (counter.Name == _webSiteCounterNames.TotalConnectionAttempts) {
+                        totalConnectionAttempts += counter.Value;
+                    }
+                    else if (counter.Name == _webSiteCounterNames.CurrentConnections) {
+                        currentConnections += counter.Value;
+                    }
+                    else if (counter.Name == _webSiteCounterNames.TotalMethodRequestsSec) {
+                        requestsSec += counter.Value;
+                    }
+                    else if (counter.Name == _webSiteCounterNames.TotalOtherMethodRequestsSec) {
+                        requestsSec += counter.Value;
+                    }
+                    else if (counter.Name == _webSiteCounterNames.TotalMethodRequests) {
+                        totalRequests += counter.Value;
+                    }
+                    else if (counter.Name == _webSiteCounterNames.TotalOtherMethodRequests) {
+                        totalRequests += counter.Value;
                     }
                 }
 
-                else if (counter.CategoryName.Equals(WorkerProcessCounterNames.Category)) {
-                    switch (counter.Name) {
-                        case WorkerProcessCounterNames.ActiveRequests:
-                            activeRequests += counter.Value;
-                            break;
-                        default:
-                            break;
+                else if (counter.CategoryName.Equals(_workerProcessCounterNames.Category)) {
+                    if (counter.Name == _workerProcessCounterNames.ActiveRequests) {
+                        activeRequests += counter.Value;
                     }
                 }
 
-                else if (counter.CategoryName.Equals(ProcessCounterNames.Category)) {
-                    switch (counter.Name) {
-                        case ProcessCounterNames.PercentCpu:
-                            percentCpuTime += counter.Value;
-                            break;
-                        case ProcessCounterNames.HandleCount:
-                            handleCount += counter.Value;
-                            break;
-                        case ProcessCounterNames.PrivateBytes:
-                            privateBytes += counter.Value;
-                            break;
-                        case ProcessCounterNames.ThreadCount:
-                            threadCount += counter.Value;
-                            break;
-                        case ProcessCounterNames.PrivateWorkingSet:
-                            privateWorkingSet += counter.Value;
-                            break;
-                        case ProcessCounterNames.WorkingSet:
-                            workingSet += counter.Value;
-                            break;
-                        case ProcessCounterNames.IOReadSec:
-                            IOReadSec += counter.Value;
-                            break;
-                        case ProcessCounterNames.IOWriteSec:
-                            IOWriteSec += counter.Value;
-                            break;
-                        case ProcessCounterNames.PageFaultsSec:
-                            pageFaultsSec += counter.Value;
-                            break;
-                        default:
-                            break;
+                else if (counter.CategoryName.Equals(_processCounterNames.Category)) {
+                    if (counter.Name == _processCounterNames.PercentCpu) {
+                        percentCpuTime += counter.Value;
+                    }
+                    else if (counter.Name == _processCounterNames.HandleCount) {
+                        handleCount += counter.Value;
+                    }
+                    else if (counter.Name == _processCounterNames.PrivateBytes) {
+                        privateBytes += counter.Value;
+                    }
+                    else if (counter.Name == _processCounterNames.ThreadCount) {
+                        threadCount += counter.Value;
+                    }
+                    else if (counter.Name == _processCounterNames.PrivateWorkingSet) {
+                        privateWorkingSet += counter.Value;
+                    }
+                    else if (counter.Name == _processCounterNames.WorkingSet) {
+                        workingSet += counter.Value;
+                    }
+                    else if (counter.Name == _processCounterNames.IOReadSec) {
+                        IOReadSec += counter.Value;
+                    }
+                    else if (counter.Name == _processCounterNames.IOWriteSec) {
+                        IOWriteSec += counter.Value;
+                    }
+                    else if (counter.Name == _processCounterNames.PageFaultsSec) {
+                        pageFaultsSec += counter.Value;
                     }
                 }
 
-                else if (counter.CategoryName.Equals(ProcessorCounterNames.Category)) {
-                    switch (counter.Name) {
-                        case ProcessorCounterNames.IdleTime:
-                            systemPercentCpuTime += 100 - counter.Value;
-                            break;
-                        default:
-                            break;
+                else if (counter.CategoryName.Equals(_processorCounterNames.Category)) {
+                    if (counter.Name == _processorCounterNames.IdleTime) {
+                        systemPercentCpuTime += 100 - counter.Value;
                     }
                 }
 
-                else if (counter.CategoryName.Equals(MemoryCounterNames.Category)) {
-                    switch (counter.Name) {
-                        case MemoryCounterNames.AvailableBytes:
-                            availableBytes += counter.Value;
-                            break;
-                        default:
-                            break;
+                else if (counter.CategoryName.Equals(_memoryCounterNames.Category)) {
+                    if (counter.Name == _memoryCounterNames.AvailableBytes) {
+                        availableBytes += counter.Value;
                     }
                 }
 
-                else if (counter.CategoryName.Equals(CacheCounterNames.Category)) {
-                    switch (counter.Name) {
-                        case CacheCounterNames.CurrentFileCacheMemoryUsage:
-                            fileCacheMemoryUsage += counter.Value;
-                            break;
-                        case CacheCounterNames.CurrentFilesCached:
-                            currentFilesCached += counter.Value;
-                            break;
-                        case CacheCounterNames.CurrentUrisCached:
-                            currentUrisCached += counter.Value;
-                            break;
-                        case CacheCounterNames.FileCacheHits:
-                            fileCacheHits += counter.Value;
-                            break;
-                        case CacheCounterNames.FileCacheMisses:
-                            fileCacheMisses += counter.Value;
-                            break;
-                        case CacheCounterNames.OutputCacheCurrentItems:
-                            outputCacheCurrentItems += counter.Value;
-                            break;
-                        case CacheCounterNames.OutputCacheCurrentMemoryUsage:
-                            outputCacheCurrentMemoryUsage += counter.Value;
-                            break;
-                        case CacheCounterNames.OutputCacheTotalHits:
-                            outputCacheTotalHits += counter.Value;
-                            break;
-                        case CacheCounterNames.OutputCacheTotalMisses:
-                            outputCacheTotalMisses += counter.Value;
-                            break;
-                        case CacheCounterNames.TotalFilesCached:
-                            totalFilesCached += counter.Value;
-                            break;
-                        case CacheCounterNames.TotalUrisCached:
-                            totalUrisCached += counter.Value;
-                            break;
-                        case CacheCounterNames.UriCacheHits:
-                            uriCacheHits += counter.Value;
-                            break;
-                        case CacheCounterNames.UriCacheMisses:
-                            uriCacheMisses += counter.Value;
-                            break;
-                        default:
-                            break;
+                else if (counter.CategoryName.Equals(_cacheCounterNames.Category)) {
+                    if (counter.Name == _cacheCounterNames.CurrentFileCacheMemoryUsage) {
+                        fileCacheMemoryUsage += counter.Value;
+                    }
+                    else if (counter.Name == _cacheCounterNames.CurrentFilesCached) {
+                        currentFilesCached += counter.Value;
+                    }
+                    else if (counter.Name == _cacheCounterNames.CurrentUrisCached) {
+                        currentUrisCached += counter.Value;
+                    }
+                    else if (counter.Name == _cacheCounterNames.FileCacheHits) {
+                        fileCacheHits += counter.Value;
+                    }
+                    else if (counter.Name == _cacheCounterNames.FileCacheMisses) {
+                        fileCacheMisses += counter.Value;
+                    }
+                    else if (counter.Name == _cacheCounterNames.OutputCacheCurrentItems) {
+                        outputCacheCurrentItems += counter.Value;
+                    }
+                    else if (counter.Name == _cacheCounterNames.OutputCacheCurrentMemoryUsage) {
+                        outputCacheCurrentMemoryUsage += counter.Value;
+                    }
+                    else if (counter.Name == _cacheCounterNames.OutputCacheTotalHits) {
+                        outputCacheTotalHits += counter.Value;
+                    }
+                    else if (counter.Name == _cacheCounterNames.OutputCacheTotalMisses) {
+                        outputCacheTotalMisses += counter.Value;
+                    }
+                    else if (counter.Name == _cacheCounterNames.TotalFilesCached) {
+                        totalFilesCached += counter.Value;
+                    }
+                    else if (counter.Name == _cacheCounterNames.TotalUrisCached) {
+                        totalUrisCached += counter.Value;
+                    }
+                    else if (counter.Name == _cacheCounterNames.UriCacheHits) {
+                        uriCacheHits += counter.Value;
+                    }
+                    else if (counter.Name == _cacheCounterNames.UriCacheMisses) {
+                        uriCacheMisses += counter.Value;
                     }
                 }
             }
@@ -281,22 +269,22 @@ namespace Microsoft.IIS.Administration.WebServer.Monitoring
             _webserverProcesses = ProcessUtil.GetWebserverProcessIds();
 
             // Only use total counter if instances are available
-            if (counterFinder.GetInstances(WebSiteCounterNames.Category).Any(i => i != TotalInstance)) {
-                counters.AddRange(await _provider.GetCounters(WebSiteCounterNames.Category, TotalInstance, WebSiteCounterNames.CounterNames));
+            if (counterFinder.GetInstances(_webSiteCounterNames.Category).Any(i => i != TotalInstance)) {
+                counters.AddRange(await _provider.GetCounters(_webSiteCounterNames.Category, TotalInstance, _webSiteCounterNames.CounterNames));
             }
 
-            if (counterFinder.GetInstances(WorkerProcessCounterNames.Category).Any(i => i != TotalInstance)) {
-                counters.AddRange(await _provider.GetCounters(WorkerProcessCounterNames.Category, TotalInstance, WorkerProcessCounterNames.CounterNames));
+            if (counterFinder.GetInstances(_workerProcessCounterNames.Category).Any(i => i != TotalInstance)) {
+                counters.AddRange(await _provider.GetCounters(_workerProcessCounterNames.Category, TotalInstance, _workerProcessCounterNames.CounterNames));
             }
 
-            counters.AddRange(await _provider.GetSingletonCounters(MemoryCounterNames.Category, MemoryCounterNames.CounterNames));
+            counters.AddRange(await _provider.GetSingletonCounters(_memoryCounterNames.Category, _memoryCounterNames.CounterNames));
 
-            counters.AddRange(await _provider.GetSingletonCounters(CacheCounterNames.Category, CacheCounterNames.CounterNames));
+            counters.AddRange(await _provider.GetSingletonCounters(_cacheCounterNames.Category, _cacheCounterNames.CounterNames));
 
-            counters.AddRange(await _provider.GetCounters(ProcessorCounterNames.Category, TotalInstance, ProcessorCounterNames.CounterNames));
+            counters.AddRange(await _provider.GetCounters(_processorCounterNames.Category, TotalInstance, _processorCounterNames.CounterNames));
 
             if (_processCounterMap == null) {
-                _processCounterMap = await ProcessUtil.GetProcessCounterMap(_provider, "w3wp");
+                _processCounterMap = await ProcessUtil.GetProcessCounterMap(_processCounterNames, _provider, "w3wp");
             }
 
             foreach (int processId in _webserverProcesses) {
@@ -304,7 +292,7 @@ namespace Microsoft.IIS.Administration.WebServer.Monitoring
                 string instanceName = await TryGetProcessCounterInstance(processId);
 
                 if (instanceName != null) {
-                    counters.AddRange(await _provider.GetCounters(ProcessCounterNames.Category, instanceName, ProcessCounterNames.CounterNames));
+                    counters.AddRange(await _provider.GetCounters(_processCounterNames.Category, instanceName, _processCounterNames.CounterNames));
                 }
             }
 
@@ -319,7 +307,7 @@ namespace Microsoft.IIS.Administration.WebServer.Monitoring
                 
                 if (p != null) {
 
-                    var map = await ProcessUtil.GetProcessCounterMap(_provider, p.ProcessName);
+                    var map = await ProcessUtil.GetProcessCounterMap(_processCounterNames, _provider, p.ProcessName);
 
                     foreach (int key in map.Keys) {
                         _processCounterMap[key] = map[key];


### PR DESCRIPTION
This pull request adds support for localized versions of Windows. The performance counter APIs take counter names as input that differ based on the language of the OS. To be able to use performance counters on localized OSes we must translate our desired performance counters from English to the language of the OS.

This logic is handled by the CounterTranslator. The translator uses the HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Perflib\{LangId} [registry entry](https://support.microsoft.com/en-us/help/287159/using-pdh-apis-correctly-in-a-localized-language) to build a map of English counter names to performance counter indexes. This map is then used to match indexes to localized counter names.

1. English counter name -> List of counter indexes
2. Counter index -> Localized Name

One drawback of this approach is that English counter names can be duplicated resulting in multiple indexes. This is the case for popular names such as _Bytes Received_. In order to solve this problem if multiple indexes are found for a single English counter name then the category that the counter name is being translated for is searched to find the specific match.

The CounterNames classes have also received a large rework due to these names no longer being constant. CounterName classes use an ICounterTranslator to provide translated versions of their known english names.