### PR TITLE
Added support for localized OSes by translating performance counter category names.

### DIFF
--- a/src/Microsoft.IIS.Administration.WebServer.Monitoring/AppPools/AppPoolMonitor.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Monitoring/AppPools/AppPoolMonitor.cs
@@ -13,19 +13,21 @@ namespace Microsoft.IIS.Administration.WebServer.Monitoring
 
     class AppPoolMonitor : IAppPoolMonitor
     {
-        CounterProvider _counterProvider;
+        ICounterProvider _counterProvider;
         private Dictionary<int, string> _processCounterInstances = null;
         private static readonly int _processorCount = Environment.ProcessorCount;
+        private CounterFinder _finder = null;
 
-        public AppPoolMonitor(CounterProvider provider)
+        public AppPoolMonitor(ICounterProvider provider, CounterFinder finder)
         {
             _counterProvider = provider;
+            _finder = finder;
         }
 
         public async Task<IEnumerable<IAppPoolSnapshot>> GetSnapshots(IEnumerable<ApplicationPool> pools)
         {
             if (_processCounterInstances == null) {
-                _processCounterInstances = await ProcessUtil.GetProcessCounterMap(_counterProvider, "W3WP");
+                _processCounterInstances = await ProcessUtil.GetProcessCounterMap(_finder, _counterProvider, "W3WP");
             }
 
             var snapshots = new List<IAppPoolSnapshot>();
@@ -176,7 +178,7 @@ namespace Microsoft.IIS.Administration.WebServer.Monitoring
 
             foreach (WorkerProcess wp in wps) {
                 if (!_processCounterInstances.ContainsKey(wp.ProcessId)) {
-                    _processCounterInstances = await ProcessUtil.GetProcessCounterMap(_counterProvider, "W3WP");
+                    _processCounterInstances = await ProcessUtil.GetProcessCounterMap(_finder, _counterProvider, "W3WP");
 
                     //
                     // Counter instance doesn't exist

--- a/src/Microsoft.IIS.Administration.WebServer.Monitoring/Core/CounterMonitor.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Monitoring/Core/CounterMonitor.cs
@@ -21,11 +21,12 @@ namespace Microsoft.IIS.Administration.Monitoring
         private Dictionary<IPerfCounter, PdhCounterHandle> _counters = new Dictionary<IPerfCounter, PdhCounterHandle>();
         private PdhQueryHandle _query;
         private DateTime _lastCalculatedTime;
-        private CounterFinder _counterFinder = new CounterFinder();
+        private CounterFinder _counterFinder;
         private ReaderWriterLockSlim _lock = new ReaderWriterLockSlim();
 
-        public CounterMonitor(IEnumerable<IPerfCounter> counters)
+        public CounterMonitor(CounterFinder finder, IEnumerable<IPerfCounter> counters)
         {
+            _counterFinder = finder;
             AddCounters(counters);
         }
 
@@ -222,7 +223,7 @@ namespace Microsoft.IIS.Administration.Monitoring
             foreach (var counter in counters) {
                 PdhCounterHandle hCounter;
 
-                result = Pdh.PdhAddCounterW(_query, counter.Path, IntPtr.Zero, out hCounter);
+                result = Pdh.PdhAddEnglishCounterW(_query, counter.Path, IntPtr.Zero, out hCounter);
                 if (result == Pdh.PDH_CSTATUS_NO_OBJECT ||
                     result == Pdh.PDH_CSTATUS_NO_COUNTER) {
                     missingCounters.Add(counter);

--- a/src/Microsoft.IIS.Administration.WebServer.Monitoring/Core/CounterTranslator.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Monitoring/Core/CounterTranslator.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+
+namespace Microsoft.IIS.Administration.Monitoring
+{
+    using Microsoft.IIS.Administration.WebServer.Monitoring;
+    using Serilog;
+    using System.Collections.Generic;
+
+    class CounterTranslator : ICounterTranslator
+    {
+        //
+        // Performance counter entries can be duplicated so that indexes for an english performance counter name are ambiguous
+        // A lookup must be created
+        // https://support.microsoft.com/en-us/help/287159/using-pdh-apis-correctly-in-a-localized-language
+
+        private Dictionary<string, List<int>> _map = null;
+        private Dictionary<int, string> _lookup = null;
+
+        public string TranslateCategory(string counterName)
+        {
+            if (_map == null) {
+                BuildLookup();
+            }
+
+            string translated = null;
+
+            if (_map.TryGetValue(counterName, out List<int> indexes)) {
+
+                if (indexes.Count > 1) {
+                    Log.Error("Ambiguous translation for performance counter category");
+                }
+
+                translated = CounterUtil.LookupName((uint)indexes[0]);
+            }
+
+            return !string.IsNullOrEmpty(translated) ? translated : counterName;
+        }
+
+        private void BuildLookup()
+        {
+            var map = CounterUtil.GetCounterIdMap();
+            var lookup = new Dictionary<int, string>();
+
+            foreach (var kvp in map) {
+
+                foreach (var index in kvp.Value) {
+                    lookup[index] = CounterUtil.LookupName((uint)index);
+                }
+            }
+
+            _map = map;
+            _lookup = lookup;
+        }
+    }
+}

--- a/src/Microsoft.IIS.Administration.WebServer.Monitoring/Core/ICounterTranslator.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Monitoring/Core/ICounterTranslator.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+
+namespace Microsoft.IIS.Administration.Monitoring
+{
+    public interface ICounterTranslator
+    {
+        string TranslateCategory(string counterName);
+    }
+}

--- a/src/Microsoft.IIS.Administration.WebServer.Monitoring/Core/Interop.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Monitoring/Core/Interop.cs
@@ -6,6 +6,7 @@ namespace Microsoft.IIS.Administration.Monitoring
 {
     using System;
     using System.Runtime.InteropServices;
+    using System.Text;
 
     public abstract class SafeHandleZeroOrMinusOneIsInvalid : SafeHandle
     {
@@ -145,7 +146,7 @@ namespace Microsoft.IIS.Administration.Monitoring
             IntPtr hQuery);
 
         [DllImport(PerformanceCounterLib, SetLastError = true, CharSet = CharSet.Unicode)]
-        public static extern UInt32 PdhAddCounterW(
+        public static extern UInt32 PdhAddEnglishCounterW(
             PdhQueryHandle hQuery,
             string szFullCounterPath,
             IntPtr dwUserData,
@@ -168,12 +169,19 @@ namespace Microsoft.IIS.Administration.Monitoring
             IntPtr lpdwType,
             out PDH_FMT_COUNTERVALUE pValue);
 
-        [DllImport(PerformanceCounterLib, SetLastError = true, CharSet = CharSet.Ansi)]
-        public static extern UInt32 PdhExpandWildCardPathA(
+        [DllImport(PerformanceCounterLib, SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern UInt32 PdhExpandWildCardPathW(
             string szdataSource,
             string szWildCardPath,
             IntPtr mszExpandedPathList,
             ref long pcchPathListLength,
             PdhExpansionFlags dwFlags);
+
+        [DllImport(PerformanceCounterLib, SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern UInt32 PdhLookupPerfNameByIndexW(
+            string szMachineName,
+            uint dwNameIndex,
+            StringBuilder szNameBuffer,
+            ref uint pcchNameBufferSize);
     }
 }

--- a/src/Microsoft.IIS.Administration.WebServer.Monitoring/Sites/WebSiteMonitor.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Monitoring/Sites/WebSiteMonitor.cs
@@ -13,20 +13,22 @@ namespace Microsoft.IIS.Administration.WebServer.Monitoring
 
     class WebSiteMonitor : IWebSiteMonitor
     {
-        private CounterProvider _counterProvider;
+        private ICounterProvider _counterProvider;
         private static readonly int _processorCount = Environment.ProcessorCount;
         private Dictionary<int, string> _processCounterInstances = null;
         private Dictionary<string, int> _siteProcessCounts = new Dictionary<string, int>();
+        private CounterFinder _finder;
 
-        public WebSiteMonitor(CounterProvider counterProvider)
+        public WebSiteMonitor(ICounterProvider counterProvider, CounterFinder finder)
         {
             _counterProvider = counterProvider;
+            _finder = finder;
         }
 
         public async Task <IEnumerable<IWebSiteSnapshot>> GetSnapshots(IEnumerable<Site> sites)
         {
             if (_processCounterInstances == null) {
-                _processCounterInstances = await ProcessUtil.GetProcessCounterMap(_counterProvider, "W3WP");
+                _processCounterInstances = await ProcessUtil.GetProcessCounterMap(_finder, _counterProvider, "W3WP");
             }
 
             var snapshots = new List<WebSiteSnapshot>();
@@ -226,7 +228,7 @@ namespace Microsoft.IIS.Administration.WebServer.Monitoring
 
                 foreach (WorkerProcess wp in wps) {
                     if (!_processCounterInstances.ContainsKey(wp.ProcessId)) {
-                        _processCounterInstances = await ProcessUtil.GetProcessCounterMap(_counterProvider, "W3WP");
+                        _processCounterInstances = await ProcessUtil.GetProcessCounterMap(_finder, _counterProvider, "W3WP");
 
                         //
                         // Counter instance doesn't exist

--- a/src/Microsoft.IIS.Administration.WebServer.Monitoring/Startup.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Monitoring/Startup.cs
@@ -18,10 +18,13 @@ namespace Microsoft.IIS.Administration.WebServer.Monitoring
 
         public void Use(IServiceCollection services)
         {
-            _provider = new CounterProvider();
-            var appPoolMonitor = new AppPoolMonitor(_provider);
-            var webserverMonitor = new WebServerMonitor(_provider);
-            var siteMonitor = new WebSiteMonitor(_provider);
+            var finder = new CounterFinder(new CounterTranslator());
+
+            _provider = new CounterProvider(finder);
+
+            var appPoolMonitor = new AppPoolMonitor(_provider, finder);
+            var webserverMonitor = new WebServerMonitor(_provider, finder);
+            var siteMonitor = new WebSiteMonitor(_provider, finder);
 
             services.AddSingleton<ICounterProvider>(_provider);
             services.AddSingleton<IAppPoolMonitor>(appPoolMonitor);

--- a/src/Microsoft.IIS.Administration.WebServer.Monitoring/Util/CounterUtil.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Monitoring/Util/CounterUtil.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+
+namespace Microsoft.IIS.Administration.WebServer.Monitoring
+{
+    using Microsoft.IIS.Administration.Monitoring;
+    using Microsoft.Win32;
+    using System.Collections.Generic;
+    using System.ComponentModel;
+    using System.Text;
+
+    class CounterUtil
+    {
+        //
+        // 009 - English Language Id
+        private const string CounterNamesRegKey = @"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Perflib\009";
+        private const string CounterNamesRegSubKey = "counter";
+
+        public static Dictionary<string, List<int>> GetCounterIdMap()
+        {
+            string[] entries = null;
+            var idMap = new Dictionary<string, List<int>>();
+
+            using (var key = Registry.LocalMachine.OpenSubKey(CounterNamesRegKey)) {
+                entries = (string[])key?.GetValue(CounterNamesRegSubKey);
+            }
+
+            if (entries != null) {
+
+                for (int i = 0; i < entries.Length - 1; i += 2) {
+
+                    string key = entries[i + 1];
+
+                    if (int.TryParse(entries[i], out int val)) {
+
+                        if (!idMap.ContainsKey(key)) {
+
+                            idMap[key] = new List<int>() { val };
+                        }
+                        else {
+
+                            idMap[key].Add(val);
+                        }
+                    }
+                }
+            }
+
+            return idMap;
+        }
+
+        public static string LookupName(uint index)
+        {
+            uint bufSize = 0;
+
+            uint result = Pdh.PdhLookupPerfNameByIndexW(null, index, null, ref bufSize);
+
+            if (result != 0 && result != Pdh.PDH_MORE_DATA) {
+                throw new Win32Exception((int)result);
+            }
+
+            StringBuilder buffer = new StringBuilder((int)bufSize);
+
+            result = Pdh.PdhLookupPerfNameByIndexW(null, index, buffer, ref bufSize);
+
+            if (result != 0) {
+                throw new Win32Exception((int)result);
+            }
+
+            return buffer.ToString();
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds support for localized versions of Windows. The performance counter APIs take counter names as input that differ based on the language of the OS. The __PdhAddEnglishCounter__ API exists to allow users to consume counters regardless of locale. 

Although the PdhAddEnglishCounter API allows us to get values for counters, it does not provide a way to list instances of a counter category. To be able to list instances of a performance counter category on localized OSes we must translate the category name from English to the language of the OS.

Performance Counter Category: Constant
Performance Counter Instance: __Variable__ (Obtained by knowing the localized category)
Performance Counter Name: Constant

This logic is handled by the CounterTranslator. The translator uses the HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Perflib{LangId} registry entry to build a map of English counter names to performance counter indexes. This map is then used to match indexes to localized counter names.

English counter category name -> List of counter indexes
Counter index -> Localized counter category Name

Once we know the translated categories for performance counters we can use the PdhAddEnglishCounter API.

