### PR TITLE
Added link to the directory that corresponds to a root location.

### DIFF
--- a/src/Microsoft.IIS.Administration.Files/Startup.cs
+++ b/src/Microsoft.IIS.Administration.Files/Startup.cs
@@ -120,6 +120,9 @@ namespace Microsoft.IIS.Administration.Files
 
             // Self (Files)
             hal.ProvideLink(Defines.LocationsResource.Guid, "self", location => new { href = $"/{Defines.LOCATIONS_PATH}/{location.id}" });
+
+            // File
+            hal.ProvideLink(Defines.LocationsResource.Guid, "directory", location => new { href = $"/{Defines.FILES_PATH}/{location.id}" });
         }
     }
 }

--- a/src/Microsoft.IIS.Administration/Configuration/ConfigurationWriter.cs
+++ b/src/Microsoft.IIS.Administration/Configuration/ConfigurationWriter.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.IIS.Administration
 {
     using Microsoft.IIS.Administration.Core;
+    using Microsoft.IIS.Administration.Files;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
     using System;
@@ -24,6 +25,20 @@ namespace Microsoft.IIS.Administration
                 throw new ArgumentNullException(nameof(name));
             }
 
+            try {
+                WriteSectionInteral(name, value);
+            }
+            catch (IOException e) {
+                if (e.HResult == HResults.FileInUse) {
+                    throw new LockedException("appsettings.json");
+                }
+
+                throw;
+            }
+        }
+
+        private void WriteSectionInteral(string name, object value)
+        {
             JToken root = JObject.Parse(File.ReadAllText(_path));
             JToken seeker = root;
             JToken parent = null;


### PR DESCRIPTION
Added a _directory_ link to the /api/files/locations/{id} resource that points to the corresponding /api/files/{id} resource.

Enhanced the ConfigurationWriter to respond with a proper API error when the appsettings.json file is unavailable for editing (in use).