### PR TITLE
Address VS2017 15.6 behavior change breaking f5 experience

### DIFF
--- a/src/Microsoft.IIS.Administration/Properties/launchSettings.json
+++ b/src/Microsoft.IIS.Administration/Properties/launchSettings.json
@@ -26,6 +26,7 @@
     },
     "Microsoft.IIS.Administration": {
       "commandName": "Project",
+      "workingDirectory": ".",
       "launchBrowser": true,
       "launchUrl": "https://localhost:44326",
       "environmentVariables": {


### PR DESCRIPTION
VS 2017 update 15.6 added a change in the debugging experience which changes the location of Directory.GetCurrentDirectory(): https://github.com/dotnet/project-system/pull/3073. Updated launchSettings.json to prevent being broken from this.