### PR TITLE
Updated setup scripts.

### DIFF
--- a/scripts/setup/cert.ps1
+++ b/scripts/setup/cert.ps1
@@ -10,7 +10,8 @@ Param (
                  "AddToTrusted",
                  "Create",
                  "Get-IISAdminCertificates",
-                 "Get-LatestIISAdminCertificate")]
+                 "Get-LatestIISAdminCertificate",
+                 "Is-IISAdminCertificate")]
     [string]
     $Command,
     
@@ -293,6 +294,27 @@ function Get-IISAdminCerts {
     $adminCerts
 }
 
+# Tests whether a provided certificate is an IIS Administration generated certificate.
+# Thumbprint: Used to filter the certificate by its thumbprint (hash).
+function Is-IISAdminCert($_thumbprint) {
+
+    $ret = $false
+
+    $certs = Get-IISAdminCerts
+    
+    foreach ($cert in $certs) {
+
+      if ($cert.Thumbprint -eq $_thumbprint) {
+          
+          $ret = $true
+
+          break
+      }
+    }
+
+    $ret
+}
+
 function Get-LatestIISAdminCert {
     $cert = $null
     $certs = Get-IISAdminCerts
@@ -321,6 +343,10 @@ switch ($Command)
     "Get-LatestIISAdminCertificate"
     {
         return Get-LatestIISAdminCert
+    }
+    "Is-IISAdminCertificate"
+    {
+        return Is-IISAdminCert $Thumbprint
     }
     "Delete"
     {

--- a/scripts/setup/install.ps1
+++ b/scripts/setup/install.ps1
@@ -421,6 +421,7 @@ function Install
 
     if ($preboundCert -ne $null) {
 
+        # We will use the IIS Admin certificate only if the pre-existing binding was using it
         $useIisAdminCert = .\cert.ps1 Is-IISAdminCertificate -Thumbprint $preboundCert.CertificateHash
     }
 

--- a/scripts/setup/migrate.ps1
+++ b/scripts/setup/migrate.ps1
@@ -137,7 +137,8 @@ function Migrate {
 
     if ($oldServiceUsesIisAdminCert -and $newServiceUsesIisAdminCert) {
 
-        # Copy over Ssl binding
+        # Migration moves an old service's settings to a new service, thus the new service will begin using the old service's port
+        # Here we copy over binding info if the services are using the IIS Administration certificate to enable certificate renewal
         $sslBindingInfo = .\net.ps1 CopySslBindingInfo -SourcePort $newServicePort -DestinationPort $oldServicePort
     }
     else {
@@ -148,8 +149,8 @@ function Migrate {
     # Remove unused binding
     if ($newServiceUsesIisAdminCert -and $oldServicePort -ne $newServicePort) {
 
-        # The new service's port is only temporary since the migration will cause it to take the value of the old service
-        # We delete the temporary ssl binding since it won't be used anymore
+        # The migration causes the new service's port to become unused since it will begin using the old service's port
+        # As long as the old service's port and new service's port aren't the same, we need to clean it up
         .\net.ps1 DeleteSslBinding -Port $newServicePort
     }
 

--- a/scripts/setup/net.ps1
+++ b/scripts/setup/net.ps1
@@ -144,7 +144,7 @@ function Copy-SslBindingInfo($sourcePort, $destPort) {
         $sourceCert = Get-Item "Cert:\LocalMachine\my\$($sourceInfo.CertificateHash)"
 
         if ($sourceCert -eq $null) {
-            "Source binding certificate not found"
+            throw "Source binding certificate not found"
         }
 
         DeleteHttpsBinding $destPort

--- a/scripts/setup/security.ps1
+++ b/scripts/setup/security.ps1
@@ -214,7 +214,7 @@ function AddUserToGroup($userPath, $_group) {
 }
 
 function Set-Acls($_path) {
-    
+
 	if ([System.String]::IsNullOrEmpty($_path)) {
 		throw "Path cannot be null"
 	}

--- a/scripts/setup/security.ps1
+++ b/scripts/setup/security.ps1
@@ -214,7 +214,7 @@ function AddUserToGroup($userPath, $_group) {
 }
 
 function Set-Acls($_path) {
-
+    
 	if ([System.String]::IsNullOrEmpty($_path)) {
 		throw "Path cannot be null"
 	}
@@ -404,7 +404,21 @@ function Add-FullControl($_path, $_identity, $_recurse) {
 						[System.Security.AccessControl.AccessControlType]::Allow)
     
     $acl = Get-Acl -Path $_path
-    $acl.SetAccessRule($fullControl)
+
+    $account = $_identity.Translate([System.Security.Principal.NTAccount])
+
+    foreach ($access in $acl.Access) {
+
+        if ($access.FileSystemRights -eq [System.Security.AccessControl.FileSystemRights]::FullControl -and
+            $access.AccessControlType -eq [System.Security.AccessControl.AccessControlType]::Allow -and
+            $access.IdentityReference -eq $account) {
+
+            return
+        }
+    }
+    
+    $acl.AddAccessRule($fullControl)
+
     Set-AclForced $_path $acl $_recurse
 }
 


### PR DESCRIPTION
Updated setup scripts so that custom certificates are not overwritten on upgrade, and unused temporary bindings are not left over.

Fixes issue #170
Fixes issue #172