### PR TITLE
New default configurations

### DIFF
--- a/scripts/Configure-DevEnvironment.ps1
+++ b/scripts/Configure-DevEnvironment.ps1
@@ -37,6 +37,7 @@ try {
 
         Write-Host "appsettings.json created at $(Join-Path $configDir "appsettings.json")"
         Write-Host "Add users to the 'users' section to grant access to the application"
+        Write-Host "Add ""manage.iis.net"" to the cors rule if you wish to manage IIS through browser"
         Write-Host "For more info about the security configuration visit https://docs.microsoft.com/en-us/iis-administration/configuration/appsettings.json#security"
     }
 

--- a/scripts/setup/globals.ps1
+++ b/scripts/setup/globals.ps1
@@ -14,12 +14,16 @@ Param (
                  "DEFAULT_SERVICE_NAME",
                  "SERVICE_DESCRIPTION",
                  "CERT_EXPIRATION_WINDOW",
-                 "CERT_NAME")]
+                 "CERT_NAME",
+                 "IIS_ADMIN_API_OWNERS",
+                 "INSTALLER_FLAG",
+                 "IIS_ADMIN_API_OWNERS_DESCRIPTION")]
     [string]
     $Command
 )
 
 $INSTALL_METHOD_KEY = "IIS_ADMIN_INSTALL_METHOD"
+$installerFlag = "This item will be removed when Microsoft IIS Administration API is uninstalled."
 
 switch ($Command)
 {
@@ -76,6 +80,15 @@ switch ($Command)
     "CERT_NAME"
     {
         return "Microsoft IIS Administration Server Certificate"
+    }
+    "IIS_ADMIN_API_OWNERS" {
+        return "Microsoft IIS Administration API Owners"
+    }
+    "INSTALLER_FLAG" {
+        return $installerFlag
+    }
+    "IIS_ADMIN_API_OWNERS_DESCRIPTION" {
+        return "Membership of this group indicates ownership and full access of Microsoft IIS Administration API. $installerFlag"
     }
     default
     {

--- a/scripts/setup/globals.ps1
+++ b/scripts/setup/globals.ps1
@@ -23,7 +23,7 @@ Param (
 )
 
 $INSTALL_METHOD_KEY = "IIS_ADMIN_INSTALL_METHOD"
-$installerFlag = "This item will be removed when Microsoft IIS Administration API is uninstalled."
+$installerFlag = "This item will be removed if the Microsoft IIS Administration API is uninstalled."
 
 switch ($Command)
 {

--- a/scripts/setup/globals.ps1
+++ b/scripts/setup/globals.ps1
@@ -82,7 +82,7 @@ switch ($Command)
         return "Microsoft IIS Administration Server Certificate"
     }
     "IIS_ADMIN_API_OWNERS" {
-        return "Microsoft IIS Administration API Owners"
+        return "IIS Administration API Owners"
     }
     "INSTALLER_FLAG" {
         return $installerFlag

--- a/scripts/setup/install.ps1
+++ b/scripts/setup/install.ps1
@@ -36,7 +36,7 @@ Param(
 
     [parameter()]
     [switch]
-    $LegacyConfigurations
+    $IncludeDefaultCors
 )
 
 
@@ -355,7 +355,7 @@ function Install
         }
     }
 
-    .\config.ps1 Write-AppSettings -Port $Port -LegacyConfigurations:$LegacyConfigurations -AppSettingsPath (Join-Path $adminRoot "Microsoft.IIS.Administration\config\appsettings.json")
+    .\config.ps1 Write-AppSettings -Port $Port -IncludeDefaultCors:$IncludeDefaultCors -AppSettingsPath (Join-Path $adminRoot "Microsoft.IIS.Administration\config\appsettings.json")
 
     # Need a cert to bind to the port the API is supposed to listen on
     $cert = $null

--- a/scripts/setup/install.ps1
+++ b/scripts/setup/install.ps1
@@ -32,7 +32,11 @@ Param(
 
     [parameter()]
     [switch]
-    $DontCopy
+    $DontCopy,
+
+    [parameter()]
+    [switch]
+    $LegacyConfigurations
 )
 
 
@@ -351,7 +355,7 @@ function Install
         }
     }
 
-    .\config.ps1 Write-AppSettings -Port $Port -AppSettingsPath (Join-Path $adminRoot "Microsoft.IIS.Administration\config\appsettings.json")
+    .\config.ps1 Write-AppSettings -Port $Port -LegacyConfigurations:$LegacyConfigurations -AppSettingsPath (Join-Path $adminRoot "Microsoft.IIS.Administration\config\appsettings.json")
 
     # Need a cert to bind to the port the API is supposed to listen on
     $cert = $null

--- a/scripts/setup/msi-setup.ps1
+++ b/scripts/setup/msi-setup.ps1
@@ -20,7 +20,7 @@ Param(
 
     [parameter()]
     [boolean]
-    $LegacyConfigurations = $true
+    $IncludeDefaultCors = $true
 )
 
 function Get-ScriptDirectory {
@@ -60,7 +60,7 @@ function Install() {
         $Port = 0
     }
 
-    .\install.ps1 -Path $adminRoot -Port $Port -DistributablePath $Path -Version $Version -ServiceName $ServiceName -LegacyConfigurations:$LegacyConfigurations -DontCopy
+    .\install.ps1 -Path $adminRoot -Port $Port -DistributablePath $Path -Version $Version -ServiceName $ServiceName -IncludeDefaultCors:$IncludeDefaultCors -DontCopy
 }
 
 function Upgrade() {
@@ -85,7 +85,7 @@ function Upgrade() {
     
     $installed = $false
     try {
-        .\install.ps1 -Path $adminRoot -Port 0 -DistributablePath $Path -Version $Version -ServiceName $ServiceName -LegacyConfigurations:$LegacyConfigurations -DontCopy
+        .\install.ps1 -Path $adminRoot -Port 0 -DistributablePath $Path -Version $Version -ServiceName $ServiceName -IncludeDefaultCors:$IncludeDefaultCors -DontCopy
         $installed = $true
         .\migrate.ps1 -Source $latest -Destination $(Join-Path $adminRoot $Version)
         try {            

--- a/scripts/setup/msi-setup.ps1
+++ b/scripts/setup/msi-setup.ps1
@@ -16,7 +16,11 @@ Param(
 
     [parameter()]
     [string]
-    $Version
+    $Version,
+
+    [parameter()]
+    [boolean]
+    $LegacyConfigurations = $true
 )
 
 function Get-ScriptDirectory {
@@ -56,7 +60,7 @@ function Install() {
         $Port = 0
     }
 
-    .\install.ps1 -Path $adminRoot -Port $Port -DistributablePath $Path -Version $Version -ServiceName $ServiceName -DontCopy
+    .\install.ps1 -Path $adminRoot -Port $Port -DistributablePath $Path -Version $Version -ServiceName $ServiceName -LegacyConfigurations:$LegacyConfigurations -DontCopy
 }
 
 function Upgrade() {
@@ -81,7 +85,7 @@ function Upgrade() {
     
     $installed = $false
     try {
-        .\install.ps1 -Path $adminRoot -Port 0 -DistributablePath $Path -Version $Version -ServiceName $ServiceName -DontCopy
+        .\install.ps1 -Path $adminRoot -Port 0 -DistributablePath $Path -Version $Version -ServiceName $ServiceName -LegacyConfigurations:$LegacyConfigurations -DontCopy
         $installed = $true
         .\migrate.ps1 -Source $latest -Destination $(Join-Path $adminRoot $Version)
         try {            

--- a/scripts/setup/security.ps1
+++ b/scripts/setup/security.ps1
@@ -170,20 +170,21 @@ function RemoveLocalGroup($_name, $verifyInstallerFlag) {
 
     $g = GetLocalGroup $_name
 
-    $installerFlag = .\globals.ps1 'INSTALLER_FLAG'
     if ($verifyInstallerFlag) {
+        $installerFlag = .\globals.ps1 'INSTALLER_FLAG'
         if (!($g.Description.Contains($installerFlag))) {
-            return
+            return $false
         }
     }
 
     if($g -ne $null) {
         if (-not($(GroupCommandletsAvailable))) {
             $localAd = GetLocalAd
-            $localAd.Children.Remove($g.Path)
+            return $localAd.Children.Remove($g.Path)
         }
         else {
             Remove-LocalGroup -Name $_name
+            return $true
         }
     }
 }

--- a/scripts/setup/security.ps1
+++ b/scripts/setup/security.ps1
@@ -49,11 +49,7 @@ Param(
     
     [parameter()]
     [switch]
-    $Recurse,
-
-    [parameter()]
-    [switch]
-    $VerifyInstallerFlag
+    $Recurse
 )
 
 # Nano Server does not support ADSI provider
@@ -162,20 +158,13 @@ function CreateLocalGroup($_name, $desc, $skipIfExists = $false) {
 
 # Deletes a local group by name.
 # Name: The name of the local group to delete.
-function RemoveLocalGroup($_name, $verifyInstallerFlag) {
+function RemoveLocalGroup($_name) {
 
 	if ([System.String]::IsNullOrEmpty($_name)) {
 		throw "Name cannot be null"
     }
 
     $g = GetLocalGroup $_name
-
-    if ($verifyInstallerFlag) {
-        $installerFlag = .\globals.ps1 'INSTALLER_FLAG'
-        if (!($g.Description.Contains($installerFlag))) {
-            return $false
-        }
-    }
 
     if($g -ne $null) {
         if (-not($(GroupCommandletsAvailable))) {
@@ -461,7 +450,7 @@ switch($Command)
     }
     "RemoveLocalGroup"
     {
-        return RemoveLocalGroup $Name $VerifyInstallerFlag
+        return RemoveLocalGroup $Name
     }
     "CurrentAdUser"
     {

--- a/scripts/setup/setup.ps1
+++ b/scripts/setup/setup.ps1
@@ -35,7 +35,11 @@ Param(
     
     [parameter()]
     [switch]
-    $DeleteBinding
+    $DeleteBinding,
+
+    [parameter()]
+    [boolean]
+    $LegacyConfigurations = $true
 )
 
 Set-StrictMode -Off
@@ -95,7 +99,7 @@ function Install() {
     }
     else {
         $ServiceName = .\globals.ps1 DEFAULT_SERVICE_NAME
-        .\install.ps1 -Path $adminRoot -Port $Port -SkipVerification:$SkipVerification -DistributablePath $DistributablePath -CertHash $CertHash -Version $Version -ServiceName $ServiceName
+        .\install.ps1 -Path $adminRoot -Port $Port -SkipVerification:$SkipVerification -DistributablePath $DistributablePath -CertHash $CertHash -Version $Version -ServiceName $ServiceName -LegacyConfigurations:$LegacyConfigurations
     }
 }
 
@@ -123,7 +127,7 @@ function Upgrade() {
 
     $installed = $false
     try {
-        .\install.ps1 -Path $adminRoot -Version $Version -SkipVerification:$SkipVerification -ServiceName $ServiceName -Port 0 -DistributablePath $DistributablePath -CertHash $CertHash
+        .\install.ps1 -Path $adminRoot -Version $Version -SkipVerification:$SkipVerification -ServiceName $ServiceName -Port 0 -DistributablePath $DistributablePath -CertHash $CertHash -LegacyConfigurations:$LegacyConfigurations
         $installed = $true
         .\migrate.ps1 -Source $latest -Destination $(Join-Path $adminRoot $Version)
     }

--- a/scripts/setup/setup.ps1
+++ b/scripts/setup/setup.ps1
@@ -39,7 +39,7 @@ Param(
 
     [parameter()]
     [boolean]
-    $LegacyConfigurations = $true
+    $IncludeDefaultCors = $true
 )
 
 Set-StrictMode -Off
@@ -99,7 +99,7 @@ function Install() {
     }
     else {
         $ServiceName = .\globals.ps1 DEFAULT_SERVICE_NAME
-        .\install.ps1 -Path $adminRoot -Port $Port -SkipVerification:$SkipVerification -DistributablePath $DistributablePath -CertHash $CertHash -Version $Version -ServiceName $ServiceName -LegacyConfigurations:$LegacyConfigurations
+        .\install.ps1 -Path $adminRoot -Port $Port -SkipVerification:$SkipVerification -DistributablePath $DistributablePath -CertHash $CertHash -Version $Version -ServiceName $ServiceName -IncludeDefaultCors:$IncludeDefaultCors
     }
 }
 
@@ -127,7 +127,7 @@ function Upgrade() {
 
     $installed = $false
     try {
-        .\install.ps1 -Path $adminRoot -Version $Version -SkipVerification:$SkipVerification -ServiceName $ServiceName -Port 0 -DistributablePath $DistributablePath -CertHash $CertHash -LegacyConfigurations:$LegacyConfigurations
+        .\install.ps1 -Path $adminRoot -Version $Version -SkipVerification:$SkipVerification -ServiceName $ServiceName -Port 0 -DistributablePath $DistributablePath -CertHash $CertHash -IncludeDefaultCors:$IncludeDefaultCors
         $installed = $true
         .\migrate.ps1 -Source $latest -Destination $(Join-Path $adminRoot $Version)
     }

--- a/scripts/setup/uninstall.ps1
+++ b/scripts/setup/uninstall.ps1
@@ -123,7 +123,12 @@ function Uninstall($_path)
     }
 
     $groupName = .\globals.ps1 'IIS_ADMIN_API_OWNERS'
-    .\security.ps1 RemoveLocalGroup -Name $groupName -VerifyInstallerFlag
+    $group = .\security.ps1 GetLocalGroup -Name $groupName
+    $installerFlag = .\globals.ps1 'INSTALLER_FLAG'
+    if (!($group.Description.Contains($installerFlag))) {
+        return $false
+    }
+    .\security.ps1 RemoveLocalGroup -Name $groupName
 
     exit 0
 }

--- a/scripts/setup/uninstall.ps1
+++ b/scripts/setup/uninstall.ps1
@@ -17,7 +17,11 @@ Param(
     
     [parameter()]
     [switch]
-    $KeepFiles
+    $KeepFiles,
+
+    [parameter()]
+    [string]
+    $IISAdminOwnersGroup = "IIS Administration API Owners"
 )
 
 .\require.ps1 Is-Administrator
@@ -121,6 +125,9 @@ function Uninstall($_path)
             }
         }
     }
+
+    Remove-LocalGroup -Name $IISAdminOwnersGroup -ErrorAction "Continue"
+
     exit 0
 }
 

--- a/scripts/setup/uninstall.ps1
+++ b/scripts/setup/uninstall.ps1
@@ -125,7 +125,7 @@ function Uninstall($_path)
     $groupName = .\globals.ps1 'IIS_ADMIN_API_OWNERS'
     $group = .\security.ps1 GetLocalGroup -Name $groupName
     $installerFlag = .\globals.ps1 'INSTALLER_FLAG'
-    if ($group.Description.Contains($installerFlag)) {
+    if ($group -and $group.Description.Contains($installerFlag)) {
         .\security.ps1 RemoveLocalGroup -Name $groupName
     }
 

--- a/scripts/setup/uninstall.ps1
+++ b/scripts/setup/uninstall.ps1
@@ -125,10 +125,9 @@ function Uninstall($_path)
     $groupName = .\globals.ps1 'IIS_ADMIN_API_OWNERS'
     $group = .\security.ps1 GetLocalGroup -Name $groupName
     $installerFlag = .\globals.ps1 'INSTALLER_FLAG'
-    if (!($group.Description.Contains($installerFlag))) {
-        return $false
+    if ($group.Description.Contains($installerFlag)) {
+        .\security.ps1 RemoveLocalGroup -Name $groupName
     }
-    .\security.ps1 RemoveLocalGroup -Name $groupName
 
     exit 0
 }

--- a/scripts/setup/uninstall.ps1
+++ b/scripts/setup/uninstall.ps1
@@ -17,11 +17,7 @@ Param(
     
     [parameter()]
     [switch]
-    $KeepFiles,
-
-    [parameter()]
-    [string]
-    $IISAdminOwnersGroup = "IIS Administration API Owners"
+    $KeepFiles
 )
 
 .\require.ps1 Is-Administrator
@@ -126,7 +122,8 @@ function Uninstall($_path)
         }
     }
 
-    Remove-LocalGroup -Name $IISAdminOwnersGroup -ErrorAction "Continue"
+    $groupName = .\globals.ps1 'IIS_ADMIN_API_OWNERS'
+    .\security.ps1 RemoveLocalGroup -Name $groupName -VerifyInstallerFlag
 
     exit 0
 }

--- a/src/Microsoft.IIS.Administration/config/appsettings.default.json
+++ b/src/Microsoft.IIS.Administration/config/appsettings.default.json
@@ -34,11 +34,6 @@
     "file_name": "audit-{Date}.txt"
   },
   "cors": {
-    "rules": [
-      {
-        "origin": "https://manage.iis.net",
-        "allow": true
-      }
-    ]
+    "rules": []
   }
 }


### PR DESCRIPTION
We will be creating a group `IIS Administration API Owners` as the default administration owner and administrator for ease of managing access policies.

Allow opting out `manage.iis.net` in cors rule. Note that it is still included by default