### PR TITLE
Added apppool recycle.

### DIFF
--- a/src/Microsoft.IIS.Administration.WebServer.AppPools/Controllers/AppPoolsController.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.AppPools/Controllers/AppPoolsController.cs
@@ -138,6 +138,9 @@ namespace Microsoft.IIS.Administration.WebServer.AppPools
                         case Status.Started:
                             appPool.Start();
                             break;
+                        case Status.Recycling:
+                            appPool.Recycle();
+                            break;
                     }
                 }
                 catch(COMException e) {

--- a/src/Microsoft.IIS.Administration.WebServer/Status.cs
+++ b/src/Microsoft.IIS.Administration.WebServer/Status.cs
@@ -13,6 +13,7 @@ namespace Microsoft.IIS.Administration.WebServer
         Stopped,
         Starting,
         Started,
+        Recycling,
     }
 
     public static class StatusExtensions


### PR DESCRIPTION
I added a case on the AppPoolsController **Patch** endpoint, to allow a status of Recycling to be sent.  This recycles the app pool.  Interestingly enough, the UI on https://manage.iis.net/ has a stop, start, and recycle for an app pool, but it appears as the recycle is implemented as a stop, check status, start.  That doesn't appear to be the same thing as a recycle.