### PR TITLE
Added console logging when IIS.Administration runs interactive

### DIFF
--- a/src/Microsoft.IIS.Administration/Microsoft.IIS.Administration.csproj
+++ b/src/Microsoft.IIS.Administration/Microsoft.IIS.Administration.csproj
@@ -88,6 +88,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="2.1.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.1.1" />

--- a/src/Microsoft.IIS.Administration/Program.cs
+++ b/src/Microsoft.IIS.Administration/Program.cs
@@ -19,8 +19,11 @@ namespace Microsoft.IIS.Administration {
             var configHelper = new ConfigurationHelper(args);
             IConfiguration config = configHelper.Build();
 
+            //
+            // Initialize runAsAService local variable
             string serviceName = config.GetValue<string>("serviceName")?.Trim();
             bool runAsAService = !string.IsNullOrEmpty(serviceName);
+
             //
             // Host
             using (var host = new WebHostBuilder()


### PR DESCRIPTION
This is for fixing https://github.com/microsoft/IIS.Administration/issues/246.

I added console and debug logging only for interactive running mode.
I have tested with the below scenarios.
1. When IIS.Administration runs as a Service, it makes  only the Audit log file  correctly.
2. When IIS.Administration runs interactive, it makes both the Audit log file and it shows the debugging information in console window according to the various logging level settings such as Information, Warning, Debug.

How to test this new feature

1. go to C:\Program Files\IIS Administration\2.3.0\Microsoft.IIS.Administration
2. open config\appsettings.json and update the logging section like this:

```
...
  "logging": {
    "enabled": true,
    "min_level": "error",
    "file_name": "log-{Date}.txt",
    "LogLevel": {
      "Default": "Debug",
      "System": "Debug",
      "Microsoft": "Debug"
    }
  },
```
3. Run dotnet Microsoft.IIS.Administration.dll
4. You will see the debug information shown on the console window

NOTE:

You can use a different logging level such as Information like this:

```
...
    "LogLevel": {
      "Default": "Information",
      "System": "Information",
      "Microsoft": "Information"
    }
```