### PR TITLE
Added LogLevel

### DIFF
--- a/src/Microsoft.IIS.Administration/config/appsettings.default.json
+++ b/src/Microsoft.IIS.Administration/config/appsettings.default.json
@@ -27,7 +27,12 @@
   "logging": {
     "enabled": true,
     "min_level": "error",
-    "file_name": "log-{Date}.txt"
+    "file_name": "log-{Date}.txt",
+    "LogLevel": {
+      "Default": "Error",
+      "System": "Error",
+      "Microsoft": "Error"
+    }
   },
   "auditing": {
     "enabled": true,


### PR DESCRIPTION
Added LogLevel section to set default error log with error.
If the default loglevel is above Warning, it can affect the performance of IIS.Administration.