### PR TITLE
generate a error eventlog if everything fails

### DIFF
--- a/src/Microsoft.IIS.Administration/Program.cs
+++ b/src/Microsoft.IIS.Administration/Program.cs
@@ -12,44 +12,50 @@ namespace Microsoft.IIS.Administration {
     using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Logging.EventLog;
     using Serilog;
+    using System;
+    using System.Diagnostics;
 
     public class Program {
         public const string EventSourceName = "Microsoft IIS Administration API";
 
         public static void Main(string[] args) {
-            //
-            // Build Config
-            var configHelper = new ConfigurationHelper(args);
-            IConfiguration config = configHelper.Build();
+            try
+            {
+                //
+                // Build Config
+                var configHelper = new ConfigurationHelper(args);
+                IConfiguration config = configHelper.Build();
 
-            //
-            // Initialize runAsAService local variable
-            string serviceName = config.GetValue<string>("serviceName")?.Trim();
-            bool runAsAService = !string.IsNullOrEmpty(serviceName);
+                //
+                // Initialize runAsAService local variable
+                string serviceName = config.GetValue<string>("serviceName")?.Trim();
+                bool runAsAService = !string.IsNullOrEmpty(serviceName);
 
-            //
-            // Host
-            using (var host = new WebHostBuilder()
-                .UseContentRoot(configHelper.RootPath)
-                .ConfigureLogging((hostingContext, logging) => {
-                    logging.AddConfiguration(hostingContext.Configuration.GetSection("Logging"));
+                //
+                // Host
+                using (var host = new WebHostBuilder()
+                    .UseContentRoot(configHelper.RootPath)
+                    .ConfigureLogging((hostingContext, logging) => {
+                        logging.AddConfiguration(hostingContext.Configuration.GetSection("Logging"));
 
                     //
                     // Console log is not available in running as a Service
-                    if (!runAsAService) {
-                        logging.AddConsole();
-                    }
+                    if (!runAsAService)
+                        {
+                            logging.AddConsole();
+                        }
 
-                    logging.AddDebug();
-                    logging.AddEventLog(new EventLogSettings() {
-                        SourceName = EventSourceName
-                    });
-                })
-                .UseUrls("https://*:55539") // Config can override it. Use "urls":"https://*:55539"
-                .UseConfiguration(config)
-                .ConfigureServices(s => s.AddSingleton(config)) // Configuration Service
-                .UseStartup<Startup>()
-                .UseHttpSys(o => {
+                        logging.AddDebug();
+                        logging.AddEventLog(new EventLogSettings()
+                        {
+                            SourceName = EventSourceName
+                        });
+                    })
+                    .UseUrls("https://*:55539") // Config can override it. Use "urls":"https://*:55539"
+                    .UseConfiguration(config)
+                    .ConfigureServices(s => s.AddSingleton(config)) // Configuration Service
+                    .UseStartup<Startup>()
+                    .UseHttpSys(o => {
                     //
                     // Kernel mode Windows Authentication
                     o.Authentication.Schemes = AuthenticationSchemes.Negotiate | AuthenticationSchemes.NTLM;
@@ -58,21 +64,33 @@ namespace Microsoft.IIS.Administration {
                     // Need anonymous to allow CORS preflight requests
                     // app.UseWindowsAuthentication ensures (if needed) the request is authenticated to proceed
                     o.Authentication.AllowAnonymous = true;
-                })
-                .Build()
-                .UseHttps()) {
+                    })
+                    .Build()
+                    .UseHttps())
+                {
 
-                if (runAsAService) {
-                    //
-                    // Run as a Service
-                    Log.Information($"Running as service: {serviceName}");
-                    host.RunAsService();
+                    if (runAsAService)
+                    {
+                        //
+                        // Run as a Service
+                        Log.Information($"Running as service: {serviceName}");
+                        host.RunAsService();
+                    }
+                    else
+                    {
+                        //
+                        // Run interactive
+                        host.Run();
+                    }
                 }
-                else {
-                    //
-                    // Run interactive
-                    host.Run();
+            } catch (Exception ex)
+            {
+                using (var shutdownLog = new EventLog("Application"))
+                {
+                    shutdownLog.Source = Program.EventSourceName;
+                    shutdownLog.WriteEntry($"Microsoft IIS Administration API has shutdown unexpectively because the error: {ex.ToString()}", EventLogEntryType.Error);
                 }
+                throw ex;
             }
         }
     }

--- a/src/Microsoft.IIS.Administration/Program.cs
+++ b/src/Microsoft.IIS.Administration/Program.cs
@@ -83,7 +83,8 @@ namespace Microsoft.IIS.Administration {
                         host.Run();
                     }
                 }
-            } catch (Exception ex)
+            }
+            catch (Exception ex)
             {
                 using (var shutdownLog = new EventLog("Application"))
                 {


### PR DESCRIPTION
As per https://github.com/microsoft/IIS.Administration/issues/274
We know that installation failed because service failed to start. However we have no trace of why the service did not start.

We will generate a event log so we can diagnose it better