### PR TITLE
Expose preloadEnabled setting on applications

### DIFF
--- a/src/Microsoft.IIS.Administration.WebServer.Applications/ApplicationHelper.cs
+++ b/src/Microsoft.IIS.Administration.WebServer.Applications/ApplicationHelper.cs
@@ -160,6 +160,12 @@ namespace Microsoft.IIS.Administration.WebServer.Applications
                 obj.enabled_protocols = app.EnabledProtocols;
             }
 
+            //
+            // preload_enabled
+            if (fields.Exists("preload_enabled") && app.Attributes["preloadEnabled"] != null) {
+                obj.preload_enabled = app.Attributes["preloadEnabled"].Value;
+            }
+
             // website
             if (fields.Exists("website")) {
                 obj.website = SiteHelper.ToJsonModelRef(site, fields.Filter("website"));
@@ -297,7 +303,20 @@ namespace Microsoft.IIS.Administration.WebServer.Applications
                 if (rootVDir != null) {
                     rootVDir.PhysicalPath = physicalPath;
                 }
+            }
 
+            if (app.Attributes["preloadEnabled"] != null) {
+
+                string preloadEnabledValue = DynamicHelper.Value(model.preload_enabled);
+
+                if (preloadEnabledValue != null) {
+                    
+                    if (!bool.TryParse(preloadEnabledValue, out bool preloadEnabled)) {
+                        throw new ApiArgumentException("preload_enabled");
+                    }
+
+                    app.SetAttributeValue("preloadEnabled", preloadEnabled);
+                }
             }
 
             if (model.application_pool != null) {


### PR DESCRIPTION
The `preloadEnabled` setting is used with application initialization to enable sending a warmup request when the application pool is started.

According to https://docs.microsoft.com/en-us/iis/configuration/system.applicationhost/sites/site/application/#compatibility this setting was introduced on the `<application>` element in IIS 8.

Since the README states that even Windows Server 2008 R2 is still supported, which comes with IIS 7.5, this setting must only be exposed when the attribute exists.

The only way I found to check if an attribute is available is to try and retrieve it through the collection indexer which returns `null` if the attribute does not exist on the element.
`GetAttribute`/`GetAttributeValue`/`SetAttributeValue` all throw an exception if an attribute with the given name is not available.

Fixes #225 