### PR TITLE
Change default build output directory to bin and other changes for making real signed builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ msbuild installer /p:configuration=release
 * Must remove previously installed versions of IIS Administration.
 * **_Repair_** does not work. Must do a full uninstall/re-install.
 * If errors occurred during installation, manually remove folder _C:\Program Files\IIS Administration_ and Windows service _"Microsoft IIS Administration"_.
+* If the step above does not fix the installation failure, manually remove user group _"IIS Administration API Owners"_ from the host machine if it exists, and run setup again.
 * If you don't have permissions for the APIs, add yourself to user group _"IIS Administration API Owners"_ on the host machine.
 * If you still don't have permissions after adding yourself to _"IIS Administration API Owners"_, add yourself to users/administrators and users/owners in appsettings.json.
 * If you have trouble viewing the Access Token created from the API Explorer in Microsoft Edge, go to [edge://settings/reset](edge://settings/reset) and reset your browser's settings.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Microsoft IIS Administration API
 
 Documentation is available at https://docs.microsoft.com/en-us/IIS-Administration 
 
-### Develop and Debug with Visual studio 2022: ###
+### Develop and Debug with Visual Studio 2022: ###
 * Clone this project
 * Load the solution (Microsoft.IIS.Administration.sln) in Visual Studio
 * Try restoring all the NuGet packages

--- a/azure-pipelines/scripts/Copy-SignedBits.ps1
+++ b/azure-pipelines/scripts/Copy-SignedBits.ps1
@@ -22,7 +22,7 @@ if (!$buildDir -or !$publishDir) {
     }
 
     if (!$buildDir) {
-        $buildDir = Join-Path $projectRoot ".builds"
+        $buildDir = Join-Path $projectRoot "bin"
     }
 
     if (!$publishDir) {
@@ -35,10 +35,9 @@ Write-Verbose "Locate build directory $buildDir"
 try {
     foreach ($bitPath in Get-ChildItem -Recurse -Filter *.dll | Resolve-Path -Relative) {
         Write-Verbose "Locate built bit $bitPath"
-        $builtBit = Join-Path $buildDir $bitPath
         $publishedBit =  Join-Path $publishDir $bitPath
         if (Test-Path $publishedBit) {
-            Copy-Item -Path $builtBit -Destination $publishedBit -Force
+            Copy-Item -Path $bitPath -Destination $publishedBit -Force
             Write-Verbose "Copied built bit to $publishedBit"
         } else {
             Write-Warning "Cannot find published bit $publishedBit"

--- a/installer/IISAdministrationSetup/files.wxs
+++ b/installer/IISAdministrationSetup/files.wxs
@@ -72,10 +72,10 @@
         <File Id="Microsoft.IIS.Administration.dll" Source="$(var.APIDir)\Microsoft.IIS.Administration.dll" />
       </Component>
       <Component Id="C_Microsoft.IIS.Administration.Core.dll" Guid="8cbce269-78f9-4bbf-b714-dc14aa17d106" Win64="$(var.IsWin64)">
-        <File Id="Microsoft.IIS.Administration.Core.dll" Source="$(var.APIDir)\plugins\Microsoft.IIS.Administration.Core.dll" />
+        <File Id="Microsoft.IIS.Administration.Core.dll" Source="$(var.APIDir)\Microsoft.IIS.Administration.Core.dll" />
       </Component>
       <Component Id="C_Microsoft.IIS.Administration.Files.Core.dll" Guid="e6dd3e96-b6bf-428d-8145-f613433da408" Win64="$(var.IsWin64)">
-        <File Id="Microsoft.IIS.Administration.Files.Core.dll" Source="$(var.APIDir)\plugins\Microsoft.IIS.Administration.Files.Core.dll" />
+        <File Id="Microsoft.IIS.Administration.Files.Core.dll" Source="$(var.APIDir)\Microsoft.IIS.Administration.Files.Core.dll" />
       </Component>
       <Component Id="C_Newtonsoft.Json.Bson.dll" Guid="d17aec10-b477-4e35-9534-71471db52908" Win64="$(var.IsWin64)">
         <File Id="Newtonsoft.Json.Bson.dll" Source="$(var.APIDir)\Newtonsoft.Json.Bson.dll" />

--- a/src/Microsoft.IIS.Administration/Microsoft.IIS.Administration.csproj
+++ b/src/Microsoft.IIS.Administration/Microsoft.IIS.Administration.csproj
@@ -157,4 +157,13 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  <PropertyGroup>
+    <integrity-local>sha384-o9KO9jVK1Q4ybtHgJCCHfgQrTRNlkT6SL3j/qMuBMlDw3MmFrgrOHCOaIMJWGgK5</integrity-local>
+    <integrity-publish>sha384-tupH/ru0xhvFDtt7pNc8XKI51y+mB1jrINPiCxmcbC/rdQT0uuyt1etOWHml29CQ</integrity-publish>
+    <layoutfile>$(AppPublishRoot)\Views\Shared\_Layout.cshtml</layoutfile>
+  </PropertyGroup>
+  <Target Name="PostPublish" AfterTargets="Publish">
+     <!-- Replace the integrity code. Need different values for local debugging and published signed files  -->
+     <Exec Command="PowerShell -Command &quot;(Get-Content $(layoutfile)) -replace '$(integrity-local)', '$(integrity-publish)' | Out-File -encoding ASCII $(layoutfile)&quot; "/>
+  </Target>
 </Project>


### PR DESCRIPTION
Change default build output directory to $projectRoot + bin. No need to call Join-Path since `Push-Location $buildDir` was just called and the current directory is $buildDir.
The integrity hash is updated at publish time for _Layout.cshtml. The one that works at local debugging does not work for signed builds